### PR TITLE
Create application, login, and preregistration TRPC routers

### DIFF
--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,8 @@
 import { exampleRouter } from "~/server/api/routers/example";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
+import { applicationRouter } from "./routers/application";
+import { loginRouter } from "./routers/login";
+import { preregistrationRouter } from "./routers/preregistration";
 
 /**
  * This is the primary router for your server.
@@ -8,6 +11,9 @@ import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
  */
 export const appRouter = createTRPCRouter({
   example: exampleRouter,
+  application: applicationRouter,
+  login: loginRouter,
+  preregistration: preregistrationRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/application.ts
+++ b/src/server/api/routers/application.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+
+export const applicationRouter = createTRPCRouter({
+  get: protectedProcedure.query(({ ctx }) => {
+    // TODO: finish body
+  }),
+
+  save: protectedProcedure.mutation(({ ctx }) => {
+    // TODO: handler body
+  }),
+});

--- a/src/server/api/routers/login.ts
+++ b/src/server/api/routers/login.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+
+export const loginRouter = createTRPCRouter({
+  reset: protectedProcedure.mutation(({ ctx }) => {
+    // TODO: handler body
+  }),
+});

--- a/src/server/api/routers/preregistration.ts
+++ b/src/server/api/routers/preregistration.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+
+export const preregistrationRouter = createTRPCRouter({
+  create: protectedProcedure.mutation(({ ctx }) => {
+    // TODO: finish body
+  }),
+});


### PR DESCRIPTION
addresses #8 #9 #4 #7

# Quick Overview of Changes

- added application router with `save` mutation and `get` query procedures.
- added login router with `reset` mutation.
- added preregistration router with `create` mutation.

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [ ] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
