### PR TITLE
Add GET all Preregistration API endpoint

### DIFF
--- a/src/pages/api/preregistration/all.ts
+++ b/src/pages/api/preregistration/all.ts
@@ -1,8 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { getServerSession } from "next-auth";
-import { Stream } from "stream";
 
 import { z } from "zod";
+import { getServerAuthSession } from "~/server/auth";
 import { db } from "~/server/db";
 
 export default async function handler(
@@ -21,7 +20,8 @@ const formatQuerySchema = z.enum(["json", "csv"]);
 
 async function GET(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const session = await getServerSession();
+    const session = await getServerAuthSession({ req, res });
+    console.log(session);
 
     if (!session) return res.status(401).json({ message: "Unauthorized" });
     if (!session.user)

--- a/src/pages/api/preregistration/all/[format].ts
+++ b/src/pages/api/preregistration/all/[format].ts
@@ -1,0 +1,61 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth";
+import { z } from "zod";
+import { db } from "~/server/db";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  switch (req.method) {
+    case "GET":
+      return await GET(req, res);
+    default:
+      return res.status(405).json({ message: "Method not allowed" });
+  }
+}
+
+const formatQuerySchema = z.enum(["json", "csv"]);
+
+async function GET(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const session = await getServerSession();
+
+    if (!session) return res.status(401).json({ message: "Unauthorized" });
+    if (!session.user)
+      return res.status(404).json({ message: "User not found" });
+
+    const user = await db.query.users.findFirst({
+      where: (users, { eq }) => eq(users.id, session.user.id),
+    });
+    const userType = user?.type;
+
+    if (userType !== "organizer") {
+      return res.status(403).json({ message: "Not an organizer. Forbidden." });
+    }
+
+    const format = formatQuerySchema.parse(req.query?.format);
+
+    if (format === "json") {
+      return jsonHandler(req, res);
+    }
+
+    if (format === "csv") {
+      return csvHandler(req, res);
+    }
+  } catch (e) {
+    console.log(
+      `Something went wrong while responding to api/preregistration/all`,
+      e,
+    );
+    return res.status(500).send({ message: "Internal server error" });
+  }
+}
+
+async function jsonHandler(req: NextApiRequest, res: NextApiResponse) {
+  // TODO: finish body
+}
+
+async function csvHandler(req: NextApiRequest, res: NextApiResponse) {
+  // TODO: finish body
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,10 +26,17 @@ export default function Home() {
               {hello.data ? hello.data.greeting : "Loading tRPC query..."}
             </p>
             <AuthShowcase />
+            <PreregistrationButton />
           </div>
         </div>
       </main>
     </>
+  );
+}
+
+function PreregistrationButton() {
+  return (
+    <a href="/api/preregistration/all?format=csv">Export Preregistrations</a>
   );
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,6 +34,10 @@ export default function Home() {
   );
 }
 
+/**
+ * Downloads the CSV if authorized as an organizer.
+ * @see ./api/preregistration/all.ts
+ */
 function PreregistrationButton() {
   return (
     <a href="/api/preregistration/all?format=csv">Export Preregistrations</a>

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -229,6 +229,8 @@ export const applicationsRelation = relations(applications, ({ one }) => ({
   users: one(users, { fields: [applications.userId], references: [users.id] }),
 }));
 
+export const userType = pgEnum("user_type", ["hacker", "organizer", "sponsor"]);
+
 export const users = createTable("user", {
   id: varchar("id", { length: 255 }).notNull().primaryKey(),
   name: varchar("name", { length: 255 }),
@@ -237,6 +239,7 @@ export const users = createTable("user", {
     mode: "date",
   }).default(sql`CURRENT_TIMESTAMP`),
   image: varchar("image", { length: 255 }),
+  type: userType("type").default("hacker"),
 });
 
 export const usersRelations = relations(users, ({ many }) => ({


### PR DESCRIPTION
closes #6 

# Quick Overview of Changes

- add GET handler for /api/preregistrations/all to get either a json or csv of all preregistrations
- made sure that the hander was protected to only organizers by adding a userType enum and type field to the user table.

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
