### PR TITLE
Eliminate overlapping local/docker postgres ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 # should be updated accordingly.
 
 # Drizzle
-DATABASE_URL="postgresql://postgres:password@localhost:5432/."
+DATABASE_URL="postgresql://postgres:password@localhost:5433/."
 
 # Next Auth
 # You can generate a new secret on the command line with:

--- a/start-database.sh
+++ b/start-database.sh
@@ -49,5 +49,5 @@ docker run -d \
 	--name $DB_CONTAINER_NAME \
 	-e POSTGRES_PASSWORD="$DB_PASSWORD" \
 	-e POSTGRES_DB=. \
-	-p 5432:5432 \
+	-p 5433:5432 \
 	docker.io/postgres && echo "Database container '$DB_CONTAINER_NAME' was successfully created"


### PR DESCRIPTION
modified start-database.sh and .env.example to eliminate overlapping default local/docker postgres ports

closes/addresses (Github Issue number)

# Quick Overview of Changes

- (added x component)
- (added y function to a service on our backend)

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
