### PR TITLE
Create Preregistration Mutation

### DIFF
--- a/src/server/api/routers/preregistration.test.ts
+++ b/src/server/api/routers/preregistration.test.ts
@@ -27,6 +27,7 @@ describe("preregistration.create", async () => {
 
     assert(!!result);
     const { id, createdAt, ...got } = result;
+    void id, createdAt;
 
     expect(got).toEqual(want);
   });

--- a/src/server/api/routers/preregistration.test.ts
+++ b/src/server/api/routers/preregistration.test.ts
@@ -1,0 +1,40 @@
+import { mockSession } from "~/server/auth";
+import { db } from "~/server/db";
+import { createInnerTRPCContext } from "../trpc";
+import { createCaller } from "../root";
+import { assert, beforeEach, describe, expect, test } from "vitest";
+import { preregistrations } from "~/server/db/schema";
+import { eq } from "drizzle-orm";
+import { PreregistrationSeeder } from "~/server/db/seed/preregistrationSeeder";
+
+const session = await mockSession(db);
+
+const ctx = createInnerTRPCContext({ session, db });
+const caller = createCaller(ctx);
+
+const testPreregistration = new PreregistrationSeeder().createRandom();
+
+describe("preregistration.create", async () => {
+  beforeEach(async () => {
+    await db
+      .delete(preregistrations)
+      .where(eq(preregistrations.email, testPreregistration.email));
+  });
+
+  test("creates a new preregistration when it does not exist", async () => {
+    const want = testPreregistration;
+    const result = await caller.preregistration.create(want);
+
+    assert(!!result);
+    const { id, createdAt, ...got } = result;
+
+    expect(got).toEqual(want);
+  });
+
+  test("throws an error if the preregistration already exists", async () => {
+    await caller.preregistration.create(testPreregistration);
+    await expect(
+      caller.preregistration.create(testPreregistration),
+    ).rejects.toThrowError();
+  });
+});

--- a/src/server/api/routers/preregistration.ts
+++ b/src/server/api/routers/preregistration.ts
@@ -1,9 +1,44 @@
-import { z } from "zod";
-
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { createInsertSchema } from "drizzle-zod";
+import { preregistrations } from "~/server/db/schema";
+import { TRPCError } from "@trpc/server";
+
+const preregistrationCreateSchema = createInsertSchema(preregistrations).omit({
+  createdAt: true,
+  id: true,
+});
 
 export const preregistrationRouter = createTRPCRouter({
-  create: protectedProcedure.mutation(({ ctx }) => {
-    // TODO: finish body
-  }),
+  create: protectedProcedure
+    .input(preregistrationCreateSchema)
+    .mutation(async ({ input, ctx }) => {
+      try {
+        const existingPreregistration =
+          await ctx.db.query.preregistrations.findFirst({
+            where: ({ email }, { eq }) => eq(email, input.email),
+          });
+
+        if (!!existingPreregistration) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Pre-registration with that email already exists.",
+          });
+        }
+
+        const createdPreregistration = await ctx.db
+          .insert(preregistrations)
+          .values(input)
+          .returning();
+
+        return createdPreregistration[0];
+      } catch (error) {
+        throw error instanceof TRPCError
+          ? error
+          : new TRPCError({
+              code: "INTERNAL_SERVER_ERROR",
+              message:
+                "Failed to create user with password" + JSON.stringify(error),
+            });
+      }
+    }),
 });


### PR DESCRIPTION
closes #4 

# Quick Overview of Changes

- added create mutation (protected) procedure for preregistering for hack western (getting added to a mailing list)
- added tests for this mutation

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
