### PR TITLE
Implement GET endpoint for applications/all

### DIFF
--- a/src/pages/api/application/all.ts
+++ b/src/pages/api/application/all.ts
@@ -1,0 +1,122 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { getServerAuthSession } from "~/server/auth";
+import { db } from "~/server/db";
+import { createCsvFile } from "~/utils/csv";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  switch (req.method) {
+    case "GET":
+      return await GET(req, res);
+    default:
+      return res.status(405).json({ message: "Method not allowed" });
+  }
+}
+
+const paramsSchema = z.object({
+  format: z.enum(["json", "csv"]),
+  mlh: z.string().length(0).optional(),
+});
+
+async function GET(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const session = await getServerAuthSession({ req, res });
+    console.log(session);
+
+    if (!session) return res.status(401).json({ message: "Unauthorized" });
+    if (!session.user)
+      return res.status(404).json({ message: "User not found" });
+
+    const user = await db.query.users.findFirst({
+      where: (users, { eq }) => eq(users.id, session.user.id),
+    });
+    const userType = user?.type;
+
+    if (userType !== "organizer") {
+      return res.status(403).json({ message: "Not an organizer. Forbidden." });
+    }
+
+    const params = paramsSchema.parse(req.query);
+    const format = params.format;
+    const isMlh = params.mlh === "" || !!params.mlh;
+
+    if (format === "csv") {
+      return csvHandler(isMlh, res);
+    }
+
+    return jsonHandler(isMlh, res);
+  } catch (e) {
+    console.log(
+      `Something went wrong while responding to api/preregistration/all`,
+      e,
+    );
+    return res.status(500).send({ message: "Internal server error" });
+  }
+}
+
+function getMlhApplications() {
+  return db.query.applications.findMany({
+    columns: {
+      firstName: true,
+      lastName: true,
+      dateOfBirth: true,
+      phoneNumber: true,
+      school: true,
+      levelOfStudy: true,
+      countryOfResidence: true,
+      agreeCodeOfConduct: true,
+      agreeShareWithMLH: true,
+      agreeEmailsFromMLH: true,
+    },
+    with: {
+      users: {
+        columns: {
+          email: true,
+        },
+      },
+    },
+  });
+}
+
+function getApplications() {
+  return db.query.applications.findMany({
+    with: {
+      users: true,
+    },
+  });
+}
+
+async function getApplicationObjects(isMlh: boolean) {
+  const applications = isMlh
+    ? await getMlhApplications()
+    : await getApplications();
+
+  return applications.map((application) => {
+    const { users, ...rest } = application;
+    return {
+      ...users,
+      ...rest,
+    };
+  });
+}
+
+async function jsonHandler(isMlh: boolean, res: NextApiResponse) {
+  const applications = await getApplicationObjects(isMlh);
+
+  return res.status(200).json(applications);
+}
+
+const FILE_NAME = "applications.csv";
+
+async function csvHandler(isMlh: boolean, res: NextApiResponse) {
+  const applications = await getApplicationObjects(isMlh);
+  const fileString = createCsvFile(applications);
+
+  res.setHeader("Content-disposition", `attachment; filename=${FILE_NAME}`);
+  res.setHeader("Content-Type", "text/csv; charset=UTF-8");
+
+  res.send(fileString);
+}

--- a/src/pages/api/preregistration/all.ts
+++ b/src/pages/api/preregistration/all.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { getServerAuthSession } from "~/server/auth";
 import { db } from "~/server/db";
+import { createCsvFile } from "~/utils/csv";
 
 export default async function handler(
   req: NextApiRequest,
@@ -37,13 +38,11 @@ async function GET(req: NextApiRequest, res: NextApiResponse) {
 
     const format = formatQuerySchema.parse(req.query?.format);
 
-    if (format === "json") {
-      return jsonHandler(res);
-    }
-
     if (format === "csv") {
       return csvHandler(res);
     }
+
+    return jsonHandler(res);
   } catch (e) {
     console.log(
       `Something went wrong while responding to api/preregistration/all`,
@@ -63,12 +62,7 @@ const FILE_NAME = "preregistrations.csv";
 
 async function csvHandler(res: NextApiResponse) {
   const preregistrations = await db.query.preregistrations.findMany();
-
-  const columnNames = Object.keys(preregistrations).join(", ") + "\n";
-  const fileString = preregistrations.reduce((acc, pr) => {
-    acc += Object.values(pr).join(", ") + "\n";
-    return acc;
-  }, columnNames);
+  const fileString = createCsvFile(preregistrations);
 
   res.setHeader("Content-disposition", `attachment; filename=${FILE_NAME}`);
   res.setHeader("Content-Type", "text/csv; charset=UTF-8");

--- a/src/pages/api/preregistration/all.ts
+++ b/src/pages/api/preregistration/all.ts
@@ -16,7 +16,9 @@ export default async function handler(
   }
 }
 
-const formatQuerySchema = z.enum(["json", "csv"]);
+const paramsSchema = z.object({
+  format: z.enum(["json", "csv"]),
+});
 
 async function GET(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -36,7 +38,7 @@ async function GET(req: NextApiRequest, res: NextApiResponse) {
       return res.status(403).json({ message: "Not an organizer. Forbidden." });
     }
 
-    const format = formatQuerySchema.parse(req.query?.format);
+    const format = paramsSchema.parse(req.query).format;
 
     if (format === "csv") {
       return csvHandler(res);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,7 +28,8 @@ export default function Home() {
               {hello.data ? hello.data.greeting : "Loading tRPC query..."}
             </p>
             <AuthShowcase />
-            <PreregistrationButton />
+            <PreregistrationsButton />
+            <ApplicationsButton />
             <div
               onClick={() => {
                 reset.mutate({ email: "oscar45697@gmail.com" });
@@ -48,9 +49,24 @@ export default function Home() {
 
 /**
  * Downloads the CSV if authorized as an organizer.
+ * @see ./api/application/all.ts
+ */
+function ApplicationsButton() {
+  return (
+    <Link
+      href="/api/application/all?format=csv&mlh"
+      className="rounded bg-white p-1"
+    >
+      Export Applications
+    </Link>
+  );
+}
+
+/**
+ * Downloads the CSV if authorized as an organizer.
  * @see ./api/preregistration/all.ts
  */
-function PreregistrationButton() {
+function PreregistrationsButton() {
   return (
     <Link
       href="/api/preregistration/all?format=csv"

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -7,7 +7,7 @@ function columnNames(
 
 export function createCsvFile(
   objects: Record<string, unknown>[],
-  separator: string = ";",
+  separator = ";",
 ): string {
   const firstRow = columnNames(objects[0] ?? {}, separator);
 

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,20 @@
+function columnNames(
+  object: Record<string, unknown>,
+  separator: string,
+): string {
+  return Object.keys(object).join(separator) + "\n";
+}
+
+export function createCsvFile(
+  objects: Record<string, unknown>[],
+  separator: string = ";",
+): string {
+  const firstRow = columnNames(objects[0] ?? {}, separator);
+
+  const fileString = objects.reduce((acc, ob) => {
+    acc += Object.values(ob).join(separator).replaceAll("\n", " ") + "\n";
+    return acc;
+  }, firstRow);
+
+  return fileString;
+}


### PR DESCRIPTION
closes #41 

# Quick Overview of Changes

- added GET handler for `applications/all` API route

<img width="1125" alt="image" src="https://github.com/hackwestern/hackwestern/assets/70033855/ff8f0141-8fb7-43e6-adbd-66816ab41da6">

<img width="598" alt="image" src="https://github.com/hackwestern/hackwestern/assets/70033855/fa428a9a-11e2-49ca-94c2-3b105a756538">

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
