### PR TITLE
Add (Application) Review Table to Drizzle Schema

### DIFF
--- a/drizzle/0001_slow_stephen_strange.sql
+++ b/drizzle/0001_slow_stephen_strange.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS "hw11_review" (
+	"reviewer_user_id" varchar(255) NOT NULL,
+	"applicant_user_id" varchar(255) NOT NULL,
+	"created_at" timestamp (3) DEFAULT now() NOT NULL,
+	"updated_at" timestamp (3) DEFAULT now() NOT NULL,
+	"question1_rating" smallint DEFAULT 0,
+	"question2_rating" smallint DEFAULT 0,
+	"question3_rating" smallint DEFAULT 0,
+	"resume_bonus" smallint DEFAULT 0,
+	"github_bonus" smallint DEFAULT 0,
+	"linkedin_bonus" smallint DEFAULT 0,
+	"otherlink_bonus" smallint DEFAULT 0,
+	"referall" boolean,
+	CONSTRAINT "hw11_review_reviewer_user_id_applicant_user_id_pk" PRIMARY KEY("reviewer_user_id","applicant_user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "hw11_application" RENAME COLUMN "idea_to_life" TO "question1";--> statement-breakpoint
+ALTER TABLE "hw11_application" RENAME COLUMN "interest_and_passions" TO "question2";--> statement-breakpoint
+ALTER TABLE "hw11_application" RENAME COLUMN "technology_inspires" TO "question3";--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "hw11_review" ADD CONSTRAINT "hw11_review_reviewer_user_id_hw11_user_id_fk" FOREIGN KEY ("reviewer_user_id") REFERENCES "public"."hw11_user"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "hw11_review" ADD CONSTRAINT "hw11_review_applicant_user_id_hw11_application_user_id_fk" FOREIGN KEY ("applicant_user_id") REFERENCES "public"."hw11_application"("user_id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "hw11_review" ADD CONSTRAINT "hw11_review_applicant_user_id_hw11_user_id_fk" FOREIGN KEY ("applicant_user_id") REFERENCES "public"."hw11_user"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "applicant_user_id_idx" ON "hw11_review" ("applicant_user_id");

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,824 @@
+{
+  "id": "1a2d4cca-2f40-4783-bb1d-71ef1ac3d04d",
+  "prevId": "9d68b394-5673-495e-b3ff-99e8a3640e1c",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.hw11_account": {
+      "name": "hw11_account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hw11_account_userId_hw11_user_id_fk": {
+          "name": "hw11_account_userId_hw11_user_id_fk",
+          "tableFrom": "hw11_account",
+          "tableTo": "hw11_user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hw11_account_provider_providerAccountId_pk": {
+          "name": "hw11_account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.hw11_application": {
+      "name": "hw11_application",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IN_PROGRESS'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_residence": {
+          "name": "country_of_residence",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_of_study": {
+          "name": "level_of_study",
+          "type": "level_of_study",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "major": {
+          "name": "major",
+          "type": "major",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "num_of_hackathons": {
+          "name": "num_of_hackathons",
+          "type": "num_of_hackathons",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "question1": {
+          "name": "question1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question2": {
+          "name": "question2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question3": {
+          "name": "question3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resume_link": {
+          "name": "resume_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_link": {
+          "name": "github_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_link": {
+          "name": "linkedin_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_link": {
+          "name": "other_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agree_code_of_conduct": {
+          "name": "agree_code_of_conduct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_share_with_sponsors": {
+          "name": "agree_share_with_sponsors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_share_with_mlh": {
+          "name": "agree_share_with_mlh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_emails_from_mlh": {
+          "name": "agree_emails_from_mlh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_will_be_18": {
+          "name": "agree_will_be_18",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "underrep_group": {
+          "name": "underrep_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ethnicity": {
+          "name": "ethnicity",
+          "type": "race/ethnicity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sexual_orientation": {
+          "name": "sexual_orientation",
+          "type": "sexual_orientation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hw11_application_user_id_hw11_user_id_fk": {
+          "name": "hw11_application_user_id_hw11_user_id_fk",
+          "tableFrom": "hw11_application",
+          "tableTo": "hw11_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hw11_preregistration": {
+      "name": "hw11_preregistration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hw11_preregistration_email_unique": {
+          "name": "hw11_preregistration_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "public.hw11_resetPasswordToken": {
+      "name": "hw11_resetPasswordToken",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hw11_resetPasswordToken_userId_hw11_user_id_fk": {
+          "name": "hw11_resetPasswordToken_userId_hw11_user_id_fk",
+          "tableFrom": "hw11_resetPasswordToken",
+          "tableTo": "hw11_user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hw11_review": {
+      "name": "hw11_review",
+      "schema": "",
+      "columns": {
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_user_id": {
+          "name": "applicant_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "question1_rating": {
+          "name": "question1_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "question2_rating": {
+          "name": "question2_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "question3_rating": {
+          "name": "question3_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "resume_bonus": {
+          "name": "resume_bonus",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "github_bonus": {
+          "name": "github_bonus",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "linkedin_bonus": {
+          "name": "linkedin_bonus",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "otherlink_bonus": {
+          "name": "otherlink_bonus",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "referall": {
+          "name": "referall",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applicant_user_id_idx": {
+          "name": "applicant_user_id_idx",
+          "columns": [
+            "applicant_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hw11_review_reviewer_user_id_hw11_user_id_fk": {
+          "name": "hw11_review_reviewer_user_id_hw11_user_id_fk",
+          "tableFrom": "hw11_review",
+          "tableTo": "hw11_user",
+          "columnsFrom": [
+            "reviewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hw11_review_applicant_user_id_hw11_application_user_id_fk": {
+          "name": "hw11_review_applicant_user_id_hw11_application_user_id_fk",
+          "tableFrom": "hw11_review",
+          "tableTo": "hw11_application",
+          "columnsFrom": [
+            "applicant_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hw11_review_applicant_user_id_hw11_user_id_fk": {
+          "name": "hw11_review_applicant_user_id_hw11_user_id_fk",
+          "tableFrom": "hw11_review",
+          "tableTo": "hw11_user",
+          "columnsFrom": [
+            "applicant_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hw11_review_reviewer_user_id_applicant_user_id_pk": {
+          "name": "hw11_review_reviewer_user_id_applicant_user_id_pk",
+          "columns": [
+            "reviewer_user_id",
+            "applicant_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.hw11_session": {
+      "name": "hw11_session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "hw11_session_userId_hw11_user_id_fk": {
+          "name": "hw11_session_userId_hw11_user_id_fk",
+          "tableFrom": "hw11_session",
+          "tableTo": "hw11_user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hw11_user": {
+      "name": "hw11_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hacker'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.hw11_verificationToken": {
+      "name": "hw11_verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "hw11_verificationToken_identifier_token_pk": {
+          "name": "hw11_verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "IN_PROGRESS",
+        "PENDING_REVIEW",
+        "IN_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED",
+        "DECLINED"
+      ]
+    },
+    "public.race/ethnicity": {
+      "name": "race/ethnicity",
+      "schema": "public",
+      "values": [
+        "American Indian or Alaskan Native",
+        "Asian / Pacific Islander",
+        "Black or African American",
+        "Hispanic",
+        "White / Caucasian",
+        "Multiple ethnicity / Other"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "Female",
+        "Male",
+        "Non-Binary",
+        "Other"
+      ]
+    },
+    "public.level_of_study": {
+      "name": "level_of_study",
+      "schema": "public",
+      "values": [
+        "Less than Secondary / High School",
+        "Secondary / High School",
+        "Undergraduate University (2 year - community college etc.)",
+        "Undergraduate University (3+ year)",
+        "Graduate University (Masters, Professional, Doctoral, etc)",
+        "Code School / Bootcamp",
+        "Other Vocational / Trade Program or Apprenticeship",
+        "Post Doctorate",
+        "Other",
+        "Not currently a student",
+        "Prefer not to answer"
+      ]
+    },
+    "public.major": {
+      "name": "major",
+      "schema": "public",
+      "values": [
+        "Computer Science",
+        "Computer Engineering",
+        "Software Engineering",
+        "Other Engineering Discipline",
+        "Information Systems",
+        "Information Technology",
+        "System Administration",
+        "Natural Sciences (Biology, Chemistry, Physics, etc.)",
+        "Mathematics/Statistics",
+        "Web Development/Web Design",
+        "Business Administration",
+        "Humanities",
+        "Social Science",
+        "Fine Arts/Performing Arts",
+        "Other"
+      ]
+    },
+    "public.num_of_hackathons": {
+      "name": "num_of_hackathons",
+      "schema": "public",
+      "values": [
+        "0",
+        "1-3",
+        "4-6",
+        "7+"
+      ]
+    },
+    "public.sexual_orientation": {
+      "name": "sexual_orientation",
+      "schema": "public",
+      "values": [
+        "Asexual / Aromantic",
+        "Pansexual, Demisexual or Omnisexual",
+        "Bisexual",
+        "Queer",
+        "Gay / Lesbian",
+        "Heterosexual / Straight",
+        "Other"
+      ]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": [
+        "hacker",
+        "organizer",
+        "sponsor"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1716846068647,
       "tag": "0000_safe_quentin_quire",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1717446092846,
+      "tag": "0001_slow_stephen_strange",
+      "breakpoints": true
     }
   ]
 }

--- a/src/pages/api/application/all.ts
+++ b/src/pages/api/application/all.ts
@@ -72,19 +72,20 @@ function getMlhApplications() {
       agreeEmailsFromMLH: true,
     },
     with: {
-      users: {
+      user: {
         columns: {
           email: true,
         },
       },
     },
+    where: ({ status }, { eq }) => eq(status, "ACCEPTED"),
   });
 }
 
 function getApplications() {
   return db.query.applications.findMany({
     with: {
-      users: true,
+      user: true,
     },
   });
 }
@@ -95,9 +96,9 @@ async function getApplicationObjects(isMlh: boolean) {
     : await getApplications();
 
   return applications.map((application) => {
-    const { users, ...rest } = application;
+    const { user, ...rest } = application;
     return {
-      ...users,
+      ...user,
       ...rest,
     };
   });

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -318,8 +318,9 @@ export const users = createTable("user", {
   type: userType("type").default("hacker"),
 });
 
-export const usersRelations = relations(users, ({ many }) => ({
+export const usersRelations = relations(users, ({ one, many }) => ({
   accounts: many(accounts),
+  application: one(applications),
 }));
 
 export const accounts = createTable(

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -195,7 +195,7 @@ export const reviews = createTable(
  * Reviews have a many-to-one relationship with applications.
  * ie. a review is for one application, but an application can have many reveiws.
  */
-export const reviewsRelation = relations(reviews, ({ one }) => ({
+export const reviewsRelations = relations(reviews, ({ one }) => ({
   reviewer: one(users, {
     fields: [reviews.reviewerUserId],
     references: [users.id],
@@ -294,7 +294,7 @@ export const applications = createTable(
  * Applications have a one-to-many relationship with Reviews,
  * ie. An application can have many reviews, but a review is only for one application.
  */
-export const applicationsRelation = relations(
+export const applicationsRelations = relations(
   applications,
   ({ one, many }) => ({
     user: one(users, {

--- a/src/server/db/seed/applicationSeeder.ts
+++ b/src/server/db/seed/applicationSeeder.ts
@@ -12,11 +12,6 @@ import {
 import { USERS } from "./userSeeder";
 import { type UserPartial, type Seeder } from ".";
 
-// const today = new Date();
-// const thirtyDaysAgo = new Date().setDate(today.getDate() - 30);
-// const fiveDaysAgo = new Date().setDate(today.getDate() - 5);
-// const fourDaysAgo = new Date().setDate(today.getDate() - 4);
-
 const schools = [
   "Western University",
   "University of Waterloo",
@@ -50,9 +45,9 @@ export class ApplicationSeeder implements Seeder<typeof applications> {
       attendedBefore: faker.datatype.boolean(),
       numOfHackathons: faker.helpers.arrayElement(numOfHackathons.enumValues),
 
-      ideaToLife: faker.lorem.paragraphs(2),
-      interestsAndPassions: faker.lorem.paragraphs(2),
-      technologyInspires: faker.lorem.paragraphs(2),
+      question1: faker.lorem.paragraphs(2),
+      question2: faker.lorem.paragraphs(2),
+      question3: faker.lorem.paragraphs(2),
 
       resumeLink: faker.internet.url(),
       githubLink: faker.internet.url(),


### PR DESCRIPTION
# Quick Overview of Changes

- added Review table to be used for storing application reviews from organizers.
- added relations for the review table for easy querying.
- ran `npm run db:generate` to generate the SQL migration files.

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
