### PR TITLE
caching github actions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,7 +1,7 @@
 name: Prettify
 on:
   pull_request:
-    branches: [main]
+    types: [review_requested]
 jobs:
   prettier:
     runs-on: ubuntu-latest

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -15,7 +15,14 @@ jobs:
         with:
           node-version: "21"
           registry-url: "https://registry.npmjs.org"
-          cache: "npm"
+          cache: "npm"          
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: Install packages
         run: npm install
       - name: Run prettier

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,7 +1,7 @@
 name: Prettify
 on:
   pull_request:
-    types: [review_requested]
+    branches: [main]
 jobs:
   prettier:
     runs-on: ubuntu-latest
@@ -15,6 +15,7 @@ jobs:
         with:
           node-version: "21"
           registry-url: "https://registry.npmjs.org"
+          cache: "npm"
       - name: Install packages
         run: npm install
       - name: Run prettier

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: "21"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"          
-      - name: Cache build
+      - name: Cache dependencies
         uses: actions/cache@v4
         with:
           path: node_modules

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,7 +1,7 @@
 name: Test and Build
 on:
   pull_request:
-    branches: [main]
+    types: [review_requested]
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -33,6 +33,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      #- name: Cache build
+      #  uses: actions/cache@v4
+      #  with:
+      #    path: |
+      #      ~/.npm
+      #      ${{ github.workspace }}/.next/cache
+      #    key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+      #    restore-keys: |
+      #      ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -25,13 +25,23 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
-      - name: Cache build
+      - name: Cache dependencies
         uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -1,7 +1,7 @@
 name: Test and Build
 on:
   pull_request:
-    types: [review_requested]
+    branches: [main]
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -23,6 +23,15 @@ jobs:
         with:
           node-version: "21"
           registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -33,16 +33,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Cache build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-            ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-
       - name: Install dependencies
         run: npm install
 


### PR DESCRIPTION
closes/addresses #43

# Quick Overview of Changes

- caching dependencies for prettier and test-and-build
- `npm install` goes down to ~5s from ~15s
- caching builds doesn't seem to actually speed up the build process

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.
