### PR TITLE
Dependency Caching in GH Actions

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -33,15 +33,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Cache build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-            ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}-
+      #- name: Cache build
+      #  uses: actions/cache@v4
+      #  with:
+      #    path: |
+      #      ~/.npm
+      #      ${{ github.workspace }}/.next/cache
+      #    key: ${{ runner.os }}-nextjs-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+      #    restore-keys: |
+      #      ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}-
 
       - name: Install dependencies
         run: rm package-lock.json && npm install

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -25,13 +25,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 
-      #- name: Cache dependencies
-      #  uses: actions/cache@v4
-      #  with:
-      #    path: node_modules
-      #    key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      #    restore-keys: |
-      #      ${{ runner.os }}-node-
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       #- name: Cache build
       #  uses: actions/cache@v4

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -33,15 +33,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      #- name: Cache build
-      #  uses: actions/cache@v4
-      #  with:
-      #    path: |
-      #      ~/.npm
-      #      ${{ github.workspace }}/.next/cache
-      #    key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
-      #    restore-keys: |
-      #      ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package.json') }}-
 
       - name: Install dependencies
         run: rm package-lock.json && npm install


### PR DESCRIPTION
closes #59 

# Quick Overview of Changes

- change cache key to `package.json` instead of `package-lock.json`
- there is still a step that removes `package-lock.json` in the build step but `node_modules` are cached so rebuilding `package-lock.json` shouldn't be a limiting step
