### PR TITLE
"Frontend" for Internal Tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10245,6 +10245,126 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.4.tgz",
+      "integrity": "sha512-AH3mO4JlFUqsYcwFUHb1wAKlebHU/Hv2u2kb1pAuRanDZ7pD/A/KPD98RHZmwsJpdHQwfEc/06mgpSzwrJYnNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.4.tgz",
+      "integrity": "sha512-QVadW73sWIO6E2VroyUjuAxhWLZWEpiFqHdZdoQ/AMpN9YWGuHV8t2rChr0ahy+irKX5mlDU7OY68k3n4tAZTg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.4.tgz",
+      "integrity": "sha512-KT6GUrb3oyCfcfJ+WliXuJnD6pCpZiosx2X3k66HLR+DMoilRb76LpWPGb4tZprawTtcnyrv75ElD6VncVamUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.4.tgz",
+      "integrity": "sha512-Alv8/XGSs/ytwQcbCHwze1HmiIkIVhDHYLjczSVrf0Wi2MvKn/blt7+S6FJitj3yTlMwMxII1gIJ9WepI4aZ/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.4.tgz",
+      "integrity": "sha512-ze0ShQDBPCqxLImzw4sCdfnB3lRmN3qGMB2GWDRlq5Wqy4G36pxtNOo2usu/Nm9+V2Rh/QQnrRc2l94kYFXO6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.4.tgz",
+      "integrity": "sha512-8dwC0UJoc6fC7PX70csdaznVMNr16hQrTDAMPvLPloazlcaWfdPogq+UpZX6Drqb1OBlwowz8iG7WR0Tzk/diQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.4.tgz",
+      "integrity": "sha512-jxyg67NbEWkDyvM+O8UDbPAyYRZqGLQDTPwvrBBeOSyVWW/jFQkQKQ70JDqDSYg1ZDdl+E3nkbFbq8xM8E9x8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.4.tgz",
+      "integrity": "sha512-twrmN753hjXRdcrZmZttb/m5xaCBFa48Dt3FbeEItpJArxriYDunWxJn+QFXdJ3hPkm4u7CKxncVvnmgQMY1ag==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,10 @@
 import { signIn, signOut, useSession } from "next-auth/react";
 import Head from "next/head";
-import Link from "next/link";
 
 import { api } from "~/utils/api";
 
 export default function Home() {
   const hello = api.example.hello.useQuery({ text: "from tRPC" });
-  const reset = api.auth.reset.useMutation();
 
   return (
     <>
@@ -28,52 +26,10 @@ export default function Home() {
               {hello.data ? hello.data.greeting : "Loading tRPC query..."}
             </p>
             <AuthShowcase />
-            <PreregistrationsButton />
-            <ApplicationsButton />
-            <div
-              onClick={() => {
-                reset.mutate({ email: "oscar45697@gmail.com" });
-                reset.mutate({ email: "hunter.chen7@pm.me" });
-                reset.mutate({ email: "basokanthan@gmail.com" });
-              }}
-              className="m-2 rounded bg-white p-2"
-            >
-              CLICK ME
-            </div>
           </div>
         </div>
       </main>
     </>
-  );
-}
-
-/**
- * Downloads the CSV if authorized as an organizer.
- * @see ./api/application/all.ts
- */
-function ApplicationsButton() {
-  return (
-    <Link
-      href="/api/application/all?format=csv&mlh"
-      className="rounded bg-white p-1"
-    >
-      Export Applications
-    </Link>
-  );
-}
-
-/**
- * Downloads the CSV if authorized as an organizer.
- * @see ./api/preregistration/all.ts
- */
-function PreregistrationsButton() {
-  return (
-    <Link
-      href="/api/preregistration/all?format=csv"
-      className="rounded bg-white p-1"
-    >
-      Export Preregistrations
-    </Link>
   );
 }
 

--- a/src/pages/internal/index.tsx
+++ b/src/pages/internal/index.tsx
@@ -9,9 +9,15 @@ const Internal = () => {
   return (
     <>
       <main className="flex min-h-screen flex-col items-center justify-center bg-[#160524]">
+        <h1 className="text-white text-3xl mb-5">
+          Internal Dashboard
+        </h1>
         <div className="flex flex-col gap-3">
-          <Button onClick={() => router.push("/internal/review")}>
-            Review
+          <Button
+            onClick={() => router.push("/internal/review")}
+            className="rounded bg-white p-1 text-center text-black hover:bg-gray-300"
+          >
+            Review Portal
           </Button>
           <PreregistrationsButton />
           <ApplicationsButton />
@@ -29,9 +35,12 @@ function ApplicationsButton() {
   return (
     <Link
       href="/api/application/all?format=csv&mlh"
-      className="rounded bg-white p-1 text-center"
     >
-      Export Applications
+      <Button
+        className="rounded bg-white p-1 text-center text-black hover:bg-gray-300 w-max w-full"
+      >
+        Export Applications
+      </Button>
     </Link>
   );
 }
@@ -44,9 +53,12 @@ function PreregistrationsButton() {
   return (
     <Link
       href="/api/preregistration/all?format=csv"
-      className="rounded bg-white p-1 text-center"
     >
-      Export Preregistrations
+      <Button
+        className="rounded bg-white p-1 text-center text-black hover:bg-gray-300 mx-auto"
+      >
+        Export Preregistrations
+      </Button>
     </Link>
   );
 }

--- a/src/pages/internal/index.tsx
+++ b/src/pages/internal/index.tsx
@@ -1,0 +1,98 @@
+import { GetServerSidePropsContext } from "next";
+import { getServerSession } from "next-auth";
+import Link from "next/link";
+import { authOptions } from "~/server/auth";
+import { db } from "~/server/db";
+import { api } from "~/utils/api";
+
+const Internal = () => {
+  const reset = api.auth.reset.useMutation();
+
+  function ResetPasswordButton({email}: {email: string}) {
+    return <div 
+      onClick={
+        () => reset.mutate({ email: email })
+      }
+      className="m-2 rounded bg-white p-2"
+    >Reset Email</div>
+  }
+
+  return (
+    <>
+      <main className="flex min-h-screen flex-col items-center justify-center bg-[#160524]">
+        <div className="flex flex-col gap-3">
+          <PreregistrationsButton />
+          <ApplicationsButton />
+          <ResetPasswordButton email="hunter.chen7@pm.me" />
+        </div>
+      </main>
+    </>
+  );
+}
+
+/**
+ * Downloads the CSV if authorized as an organizer.
+ * @see ./api/application/all.tswsl --set-default-version 2
+ */
+function ApplicationsButton() {
+  return (
+    <Link
+      href="/api/application/all?format=csv&mlh"
+      className="rounded bg-white p-1 text-center"
+    >
+      Export Applications
+    </Link>
+  );
+}
+
+/**
+ * Downloads the CSV if authorized as an organizer.
+ * @see ./api/preregistration/all.ts
+ */
+function PreregistrationsButton() {
+  return (
+    <Link
+      href="/api/preregistration/all?format=csv"
+      className="rounded bg-white p-1 text-center"
+    >
+      Export Preregistrations
+    </Link>
+  );
+}
+
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext,
+) => {
+  const session = await getServerSession(context.req, context.res, authOptions);
+
+  if (!session) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  const user = await db.query.users.findFirst({
+    where: (users, { eq }) => eq(users.id, session.user.id),
+  });
+  console.log(user);
+  const userType = user?.type;
+
+  if (userType !== "organizer") {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {},
+  };
+};
+
+
+export default Internal;

--- a/src/pages/internal/index.tsx
+++ b/src/pages/internal/index.tsx
@@ -1,29 +1,20 @@
-import { GetServerSidePropsContext } from "next";
-import { getServerSession } from "next-auth";
 import Link from "next/link";
-import { authOptions } from "~/server/auth";
-import { db } from "~/server/db";
-import { api } from "~/utils/api";
+import { useRouter } from "next/router";
+import { Button } from "~/components/ui/button";
+import { authRedirect } from "~/utils/redirect";
 
 const Internal = () => {
-  const reset = api.auth.reset.useMutation();
-
-  function ResetPasswordButton({email}: {email: string}) {
-    return <div 
-      onClick={
-        () => reset.mutate({ email: email })
-      }
-      className="m-2 rounded bg-white p-2"
-    >Reset Email</div>
-  }
+  const router = useRouter();
 
   return (
     <>
       <main className="flex min-h-screen flex-col items-center justify-center bg-[#160524]">
         <div className="flex flex-col gap-3">
+          <Button onClick={() => router.push("/internal/review")}>
+            Review
+          </Button>
           <PreregistrationsButton />
           <ApplicationsButton />
-          <ResetPasswordButton email="hunter.chen7@pm.me" />
         </div>
       </main>
     </>
@@ -60,39 +51,6 @@ function PreregistrationsButton() {
   );
 }
 
-export const getServerSideProps = async (
-  context: GetServerSidePropsContext,
-) => {
-  const session = await getServerSession(context.req, context.res, authOptions);
-
-  if (!session) {
-    return {
-      redirect: {
-        destination: "/",
-        permanent: false,
-      },
-    };
-  }
-
-  const user = await db.query.users.findFirst({
-    where: (users, { eq }) => eq(users.id, session.user.id),
-  });
-  console.log(user);
-  const userType = user?.type;
-
-  if (userType !== "organizer") {
-    return {
-      redirect: {
-        destination: "/",
-        permanent: false,
-      },
-    };
-  }
-
-  return {
-    props: {},
-  };
-};
-
+export const getServerSideProps = authRedirect;
 
 export default Internal;

--- a/src/pages/internal/index.tsx
+++ b/src/pages/internal/index.tsx
@@ -9,9 +9,7 @@ const Internal = () => {
   return (
     <>
       <main className="flex min-h-screen flex-col items-center justify-center bg-[#160524]">
-        <h1 className="text-white text-3xl mb-5">
-          Internal Dashboard
-        </h1>
+        <h1 className="mb-5 text-3xl text-white">Internal Dashboard</h1>
         <div className="flex flex-col gap-3">
           <Button
             onClick={() => router.push("/internal/review")}
@@ -25,7 +23,7 @@ const Internal = () => {
       </main>
     </>
   );
-}
+};
 
 /**
  * Downloads the CSV if authorized as an organizer.
@@ -33,12 +31,8 @@ const Internal = () => {
  */
 function ApplicationsButton() {
   return (
-    <Link
-      href="/api/application/all?format=csv&mlh"
-    >
-      <Button
-        className="rounded bg-white p-1 text-center text-black hover:bg-gray-300 w-max w-full"
-      >
+    <Link href="/api/application/all?format=csv&mlh">
+      <Button className="w-full w-max rounded bg-white p-1 text-center text-black hover:bg-gray-300">
         Export Applications
       </Button>
     </Link>
@@ -51,12 +45,8 @@ function ApplicationsButton() {
  */
 function PreregistrationsButton() {
   return (
-    <Link
-      href="/api/preregistration/all?format=csv"
-    >
-      <Button
-        className="rounded bg-white p-1 text-center text-black hover:bg-gray-300 mx-auto"
-      >
+    <Link href="/api/preregistration/all?format=csv">
+      <Button className="mx-auto rounded bg-white p-1 text-center text-black hover:bg-gray-300">
         Export Preregistrations
       </Button>
     </Link>

--- a/src/pages/internal/review.tsx
+++ b/src/pages/internal/review.tsx
@@ -1,0 +1,7 @@
+const Review = () => {
+    return (
+        <div>Review</div>
+    )
+}
+
+export default Review;

--- a/src/pages/internal/review.tsx
+++ b/src/pages/internal/review.tsx
@@ -1,10 +1,8 @@
 import { authRedirect } from "~/utils/redirect";
 
 const Review = () => {
-    return (
-        <div>Review</div>
-    )
-}
+  return <div>Review</div>;
+};
 
 export default Review;
 export const getServerSideProps = authRedirect;

--- a/src/pages/internal/review.tsx
+++ b/src/pages/internal/review.tsx
@@ -1,3 +1,5 @@
+import { authRedirect } from "~/utils/redirect";
+
 const Review = () => {
     return (
         <div>Review</div>
@@ -5,3 +7,4 @@ const Review = () => {
 }
 
 export default Review;
+export const getServerSideProps = authRedirect;

--- a/src/pages/internal/test-password-reset.tsx
+++ b/src/pages/internal/test-password-reset.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+import { Input } from "~/components/ui/input";
+import { api } from "~/utils/api";
+// import { OrganizerRedirect } from "~/lib/authRedirect";
+import { authRedirect } from "../../utils/redirect";
+
+const TestPasswordReset = () => {
+    const reset = api.auth.reset.useMutation();
+    const [email, setEmail] = useState("");
+
+    return <main className="flex min-h-screen flex-col items-center justify-center bg-[#160524]">
+        <Input 
+            className="w-96"
+            onChange={(e) => setEmail(e.target.value)}
+            value={email}
+            placeholder="email"
+        />
+        <div
+            onClick={() => reset.mutate({ email })}
+            className="m-2 rounded bg-white p-2 cursor-pointer"
+        >Reset Password</div>
+    </main>
+
+}
+
+export default TestPasswordReset;
+export const getServerSideProps = authRedirect;

--- a/src/pages/internal/test-password-reset.tsx
+++ b/src/pages/internal/test-password-reset.tsx
@@ -5,23 +5,26 @@ import { api } from "~/utils/api";
 import { authRedirect } from "../../utils/redirect";
 
 const TestPasswordReset = () => {
-    const reset = api.auth.reset.useMutation();
-    const [email, setEmail] = useState("");
+  const reset = api.auth.reset.useMutation();
+  const [email, setEmail] = useState("");
 
-    return <main className="flex min-h-screen flex-col items-center justify-center bg-[#160524]">
-        <Input 
-            className="w-96"
-            onChange={(e) => setEmail(e.target.value)}
-            value={email}
-            placeholder="email"
-        />
-        <div
-            onClick={() => reset.mutate({ email })}
-            className="m-2 rounded bg-white p-2 cursor-pointer"
-        >Reset Password</div>
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-[#160524]">
+      <Input
+        className="w-96"
+        onChange={(e) => setEmail(e.target.value)}
+        value={email}
+        placeholder="email"
+      />
+      <div
+        onClick={() => reset.mutate({ email })}
+        className="m-2 cursor-pointer rounded bg-white p-2"
+      >
+        Reset Password
+      </div>
     </main>
-
-}
+  );
+};
 
 export default TestPasswordReset;
 export const getServerSideProps = authRedirect;

--- a/src/pages/ui.tsx
+++ b/src/pages/ui.tsx
@@ -215,7 +215,7 @@ export const getServerSideProps = async (
   const user = await db.query.users.findFirst({
     where: (users, { eq }) => eq(users.id, session.user.id),
   });
-  console.log(user);
+
   const userType = user?.type;
 
   if (userType !== "organizer") {

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -4,37 +4,37 @@ import { authOptions } from "~/server/auth";
 import { db } from "~/server/db";
 
 export const authRedirect = async (
-    context: GetServerSidePropsContext,
-    destination = '/',
-    userTypeTarget = 'organizer'
+  context: GetServerSidePropsContext,
+  destination = "/",
+  userTypeTarget = "organizer",
 ) => {
-    const session = await getServerSession(context.req, context.res, authOptions);
+  const session = await getServerSession(context.req, context.res, authOptions);
 
-    if (!session) {
-        return {
-            redirect: {
-                destination,
-                permanent: false,
-            },
-        };
-    }
-
-    const user = await db.query.users.findFirst({
-        where: (users, { eq }) => eq(users.id, session.user.id),
-    });
-
-    const userType = user?.type;
-
-    if (userType !== userTypeTarget) {
-        return {
-            redirect: {
-                destination,
-                permanent: false,
-            },
-        };
-    }
-
+  if (!session) {
     return {
-        props: {},
+      redirect: {
+        destination,
+        permanent: false,
+      },
     };
+  }
+
+  const user = await db.query.users.findFirst({
+    where: (users, { eq }) => eq(users.id, session.user.id),
+  });
+
+  const userType = user?.type;
+
+  if (userType !== userTypeTarget) {
+    return {
+      redirect: {
+        destination,
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {},
+  };
 };

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -1,0 +1,40 @@
+import { GetServerSidePropsContext } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "~/server/auth";
+import { db } from "~/server/db";
+
+export const authRedirect = async (
+    context: GetServerSidePropsContext,
+    destination = '/',
+    userTypeTarget = 'organizer'
+) => {
+    const session = await getServerSession(context.req, context.res, authOptions);
+
+    if (!session) {
+        return {
+            redirect: {
+                destination,
+                permanent: false,
+            },
+        };
+    }
+
+    const user = await db.query.users.findFirst({
+        where: (users, { eq }) => eq(users.id, session.user.id),
+    });
+
+    const userType = user?.type;
+
+    if (userType !== userTypeTarget) {
+        return {
+            redirect: {
+                destination,
+                permanent: false,
+            },
+        };
+    }
+
+    return {
+        props: {},
+    };
+};


### PR DESCRIPTION
closes #56 

# Overview

- creates a internal dashboard page at `/internal`
- added a `redirect` util that redirects to home page when not authorized
- add input for reset password input, the path is `/internal/test-password-reset`, authorized for oragnizers
- remove buttons from index

![image](https://github.com/hackwestern/hackwestern/assets/34012681/41b1e543-b1d4-4b6e-b080-73251d7c6f21)
![image](https://github.com/hackwestern/hackwestern/assets/34012681/7f78dfda-dd96-40ef-9fea-f9d6d7a87a5e)

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [ ] Check that CI is passing.
- [ ] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
