### PR TITLE
Fix Github and LinkedIn links

### DIFF
--- a/src/components/apply/form/basics-form.tsx
+++ b/src/components/apply/form/basics-form.tsx
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import type { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import {

--- a/src/components/apply/form/links-form.tsx
+++ b/src/components/apply/form/links-form.tsx
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import type { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { ClipboardEvent } from "react";
 import { useForm } from "react-hook-form";

--- a/src/components/apply/form/links-form.tsx
+++ b/src/components/apply/form/links-form.tsx
@@ -47,12 +47,15 @@ export function LinksForm() {
             <FormItem>
               <FormLabel>Github</FormLabel>
               <FormControl>
-                <Input
-                  {...field}
-                  value={field.value ?? ""}
-                  placeholder="github.com/hacker"
-                  variant="primary"
-                />
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <span>github.com/</span>
+                  <Input
+                    {...field}
+                    value={field.value ?? ""}
+                    placeholder="hacker"
+                    variant="primary"
+                  />
+                </div>
               </FormControl>
             </FormItem>
           )}
@@ -64,12 +67,15 @@ export function LinksForm() {
             <FormItem>
               <FormLabel>LinkedIn</FormLabel>
               <FormControl>
-                <Input
-                  {...field}
-                  value={field.value ?? ""}
-                  placeholder="linkedin.com/in/hacker"
-                  variant="primary"
-                />
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <span>linkedin.com/in/</span>
+                  <Input
+                    {...field}
+                    value={field.value ?? ""}
+                    placeholder="hacker"
+                    variant="primary"
+                  />
+                </div>
               </FormControl>
             </FormItem>
           )}

--- a/src/components/apply/form/links-form.tsx
+++ b/src/components/apply/form/links-form.tsx
@@ -45,7 +45,7 @@ export function LinksForm() {
     const githubUsername = getGithubUsername(pastedText);
 
     form.setValue("githubLink", githubUsername);
-    form.handleSubmit(onSubmit)();
+    return form.handleSubmit(onSubmit)();
   }
 
   function onLinkedinPaste(e: ClipboardEvent<HTMLInputElement>) {
@@ -54,7 +54,7 @@ export function LinksForm() {
     const linkedinUsername = getLinkedinUsername(pastedText);
 
     form.setValue("linkedInLink", linkedinUsername);
-    form.handleSubmit(onSubmit)();
+    return form.handleSubmit(onSubmit)();
   }
 
   return (

--- a/src/components/apply/form/links-form.tsx
+++ b/src/components/apply/form/links-form.tsx
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
+import type { ClipboardEvent } from "react";
 import { useForm } from "react-hook-form";
 import {
   Form,
@@ -12,6 +13,7 @@ import { Input } from "~/components/ui/input";
 import { api } from "~/utils/api";
 import { useAutoSave } from "~/components/hooks/use-auto-save";
 import { linksSaveSchema } from "~/schemas/application";
+import { getGithubUsername, getLinkedinUsername } from "~/utils/urls";
 
 export function LinksForm() {
   const utils = api.useUtils();
@@ -37,6 +39,24 @@ export function LinksForm() {
     });
   }
 
+  function onGithubPaste(e: ClipboardEvent<HTMLInputElement>) {
+    e.preventDefault();
+    const pastedText = e.clipboardData.getData("text");
+    const githubUsername = getGithubUsername(pastedText);
+
+    form.setValue("githubLink", githubUsername);
+    form.handleSubmit(onSubmit)();
+  }
+
+  function onLinkedinPaste(e: ClipboardEvent<HTMLInputElement>) {
+    e.preventDefault();
+    const pastedText = e.clipboardData.getData("text");
+    const linkedinUsername = getLinkedinUsername(pastedText);
+
+    form.setValue("linkedInLink", linkedinUsername);
+    form.handleSubmit(onSubmit)();
+  }
+
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-2">
@@ -50,6 +70,7 @@ export function LinksForm() {
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <span>github.com/</span>
                   <Input
+                    onPaste={onGithubPaste}
                     {...field}
                     value={field.value ?? ""}
                     placeholder="hacker"
@@ -70,6 +91,7 @@ export function LinksForm() {
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
                   <span>linkedin.com/in/</span>
                   <Input
+                    onPaste={onLinkedinPaste}
                     {...field}
                     value={field.value ?? ""}
                     placeholder="hacker"

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,2 +1,35 @@
 export const GITHUB_URL = "https://github.com/";
 export const LINKEDIN_URL = "https://linkedin.com/in/";
+
+export function getGithubUsername(text: string) {
+  try {
+    const url = new URL(text.startsWith("http") ? text : `https://${text}`);
+
+    if (url.hostname === "github.com") {
+      const pathSegments = url.pathname.split("/");
+      return pathSegments[1] ?? text;
+    }
+  } catch (error) {
+    return text;
+  }
+
+  return text;
+}
+
+export function getLinkedinUsername(text: string) {
+  try {
+    const url = new URL(text.startsWith("http") ? text : `https://${text}`);
+
+    if (
+      url.hostname === "linkedin.com" ||
+      url.hostname === "www.linkedin.com"
+    ) {
+      const pathSegments = url.pathname.split("/");
+      return pathSegments[2] ?? text;
+    }
+  } catch (error) {
+    return text;
+  }
+
+  return text;
+}


### PR DESCRIPTION
closes/addresses #127 

<img width="557" alt="image" src="https://github.com/user-attachments/assets/bff72893-712f-47b5-8dcb-52bcce817491">

# Quick Overview of Changes

- add github.com/ and linkedin.com/in/ labels
- support pasting github.com and linkedin.com/in/ links and extracting the username into the input

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
