### PR TITLE
add `"@rollup/rollup-linux-x64-gnu"` dev dep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: rm package-lock.json && npm install
+        run: npm install
 
       - name: Start Postgres DB
         run: npm run db:start && sleep 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,8 @@
         "tailwindcss": "^3.4.1",
         "tsx": "^4.11.0",
         "typescript": "^5.4.2",
-        "vitest": "^1.6.0"
+        "vitest": "^1.6.0",
+        "@rollup/rollup-linux-x64-gnu": "*"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "tailwindcss": "^3.4.1",
     "tsx": "^4.11.0",
     "typescript": "^5.4.2",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "@rollup/rollup-linux-x64-gnu": "*"
   },
   "ct3aMetadata": {
     "initVersion": "7.30.1"


### PR DESCRIPTION
# Quick Overview of Changes

- add `"@rollup/rollup-linux-x64-gnu"` dev dep to fix the issue with vitest sometimes not running
