### PR TITLE
Fix Auto Save By Only Saving Once

### DIFF
--- a/src/components/apply/form/links-form.tsx
+++ b/src/components/apply/form/links-form.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -131,6 +132,9 @@ export function LinksForm() {
                   variant="primary"
                 />
               </FormControl>
+              <FormDescription>
+                Make sure that this link is public.
+              </FormDescription>
             </FormItem>
           )}
         />

--- a/src/components/hooks/use-auto-save.ts
+++ b/src/components/hooks/use-auto-save.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { type FieldValues, useWatch, type useForm } from "react-hook-form";
 import { debounce } from "~/lib/utils";
 import useDeepCompareEffect from "use-deep-compare-effect";
@@ -8,6 +8,7 @@ export function useAutoSave<TFieldValues extends FieldValues = FieldValues>(
   onSubmit: (data: TFieldValues) => void,
   defaultValues: TFieldValues | null | undefined,
 ) {
+  const [hasReset, setHasReset] = useState(false);
   const watch = useWatch({ control: context.control });
   const { dirtyFields } = context.formState;
   const hasDirtyFields = Object.keys(dirtyFields).length > 0;
@@ -24,10 +25,11 @@ export function useAutoSave<TFieldValues extends FieldValues = FieldValues>(
   );
 
   useEffect(() => {
-    if (defaultValues) {
+    if (defaultValues && !hasReset) {
       context.reset(defaultValues);
+      setHasReset(true);
     }
-  }, [context, defaultValues]);
+  }, [defaultValues]);
 
   useDeepCompareEffect(() => {
     if (hasDirtyFields) {

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -73,7 +73,7 @@ function getApplyLink(status: ApplicationStatusType | undefined) {
     case "PENDING_REVIEW":
       return "/apply?step=review";
     default:
-      return "/apply?step=review";
+      return "/apply?step=persona";
   }
 }
 


### PR DESCRIPTION
Addresses issue where user's input is reset once the new application is fetched.

# Quick Overview of Changes

- made useAutoSave hook only reset the form once (when the default values first change)
- add description to resume input about making sure that the link is public

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
