### PR TITLE
[App Portal] Fix users needing to verify their email for OAuth accounts

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -9,8 +9,6 @@ import { notVerifiedRedirect } from "~/utils/redirect";
 import Image from "next/image";
 import Link from "next/link";
 import { cn } from "~/lib/utils";
-import { useToast } from "~/components/hooks/use-toast";
-import { useState } from "react";
 
 type ApplicationStatusType =
   | "IN_PROGRESS"

--- a/src/pages/verify.tsx
+++ b/src/pages/verify.tsx
@@ -6,6 +6,7 @@ import { api } from "~/utils/api";
 import { useToast } from "~/components/hooks/use-toast";
 import { useRouter } from "next/router";
 import { Button } from "~/components/ui/button";
+import { isVerifiedRedirect } from "~/utils/redirect";
 
 const Verify = () => {
   const router = useRouter();
@@ -69,8 +70,7 @@ const Verify = () => {
     } else {
       setVerifyFailed(true);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [verifyToken, verifyEmail]);
 
   const handleResendVerification = () => {
     if (!verificationSent) {
@@ -196,3 +196,4 @@ const Verify = () => {
 };
 
 export default Verify;
+export const getServerSideProps = isVerifiedRedirect;

--- a/src/pages/verify.tsx
+++ b/src/pages/verify.tsx
@@ -69,7 +69,8 @@ const Verify = () => {
     } else {
       setVerifyFailed(true);
     }
-  }, [verifyToken, verifyEmail]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleResendVerification = () => {
     if (!verificationSent) {

--- a/src/server/api/routers/auth.ts
+++ b/src/server/api/routers/auth.ts
@@ -215,22 +215,7 @@ export const authRouter = createTRPCRouter({
 
     const user = await db.query.users.findFirst({
       where: eq(users.id, ctx.session.user.id),
-      with: {
-        accounts: true,
-      },
     });
-
-    const isOAuthUser = !!user?.accounts.some((ac) => ac.type === "oauth");
-    const now = new Date();
-
-    if (isOAuthUser && !user?.emailVerified) {
-      await db
-        .update(users)
-        .set({
-          emailVerified: now,
-        })
-        .where(eq(users.id, ctx.session.user.id));
-    }
 
     if (!user) {
       throw new TRPCError({
@@ -240,7 +225,7 @@ export const authRouter = createTRPCRouter({
     }
 
     return {
-      verified: user.emailVerified ?? now,
+      verified: user.emailVerified,
     };
   }),
 

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -119,9 +119,6 @@ export const isVerifiedRedirect = async (
 
   const user = await db.query.users.findFirst({
     where: (users, { eq }) => eq(users.id, session?.user.id),
-    with: {
-      accounts: true,
-    },
   });
 
   // redirect to dashboard if user is verified, or they don't have a password (oauth user)

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -148,7 +148,7 @@ export const isVerifiedRedirect = async (
       .where(eq(users.id, session.user.id));
   }
 
-  if (user?.emailVerified || isOAuthUser) {
+  if (!!user?.emailVerified || isOAuthUser) {
     return {
       redirect: {
         destination: "/dashboard",

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -82,9 +82,6 @@ export const notVerifiedRedirect = async (
 
   const user = await db.query.users.findFirst({
     where: (users, { eq }) => eq(users.id, session?.user.id),
-    with: {
-      accounts: true,
-    },
   });
 
   const emailIsVerified = !!user?.emailVerified;


### PR DESCRIPTION
- tested locally by deleting my account/user/session/application from the db, and signing in again. It no longer redirects me to /verify, skipping that flow entirely.

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
