### PR TITLE
add review status check to get endpoint

### DIFF
--- a/src/server/api/routers/review.ts
+++ b/src/server/api/routers/review.ts
@@ -144,7 +144,7 @@ export const reviewRouter = createTRPCRouter({
         await db
           .select()
           .from(reviews)
-          .where(sql`${reviews.reviewerUserId}=${ctx.session.user.id}`)
+          .where(sql`${reviews.reviewerUserId}=${ctx.session.user.id} AND ${reviews.completed} IS NOT TRUE`)
           .limit(1)
       )[0];
 

--- a/src/server/api/routers/review.ts
+++ b/src/server/api/routers/review.ts
@@ -144,7 +144,9 @@ export const reviewRouter = createTRPCRouter({
         await db
           .select()
           .from(reviews)
-          .where(sql`${reviews.reviewerUserId}=${ctx.session.user.id} AND ${reviews.completed} IS NOT TRUE`)
+          .where(
+            sql`${reviews.reviewerUserId}=${ctx.session.user.id} AND ${reviews.completed} IS NOT TRUE`,
+          )
           .limit(1)
       )[0];
 


### PR DESCRIPTION
closes/addresses #207 

# Quick Overview of Changes

- Add query param for completion status when calling the `get` endpoint and expecting an existing review

# Checklist
- [x] Checked all uses of changed component(s)/function(s)
- [ ] Check that CI is passing.
- [ ] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
