### PR TITLE
[App Portal] Close Applications After Deadline

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,5 @@
+export const APPLICATION_DEADLINE = new Date("2024-10-16T23:59:00-05:00");
+
+export function isPastDeadline() {
+  return Date.now().valueOf() >= APPLICATION_DEADLINE.valueOf();
+}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -5,10 +5,11 @@ import { ApplyNavbar } from "~/components/apply/navbar";
 import { Passport } from "~/components/apply/passport";
 import { Button } from "~/components/ui/button";
 import { api } from "~/utils/api";
-import { APPLICATION_DEADLINE, notVerifiedRedirect } from "~/utils/redirect";
+import { notVerifiedRedirect } from "~/utils/redirect";
 import Image from "next/image";
 import Link from "next/link";
 import { cn } from "~/lib/utils";
+import { isPastDeadline } from "~/lib/date";
 
 type ApplicationStatusType =
   | "IN_PROGRESS"
@@ -37,10 +38,6 @@ function getParsedStatus(status: ApplicationStatusType) {
   }
 
   return parsedStatuses[status];
-}
-
-function isPastDeadline() {
-  return Date.now().valueOf() >= APPLICATION_DEADLINE.valueOf();
 }
 
 const statusClassName = {

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -3,6 +3,8 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "~/server/auth";
 import { db } from "~/server/db";
 
+export const APPLICATION_DEADLINE = new Date("2024-10-16T23:59:00-05:00");
+
 const authRedirect = async (
   context: GetServerSidePropsContext,
   destination: string,
@@ -93,6 +95,16 @@ export const notVerifiedRedirect = async (
     return {
       redirect: {
         destination: "/not-verified",
+        permanent: false,
+      },
+    };
+  }
+
+  const currentDate = Date.now();
+  if (currentDate.valueOf() >= APPLICATION_DEADLINE.valueOf()) {
+    return {
+      redirect: {
+        destination: "/dashboard",
         permanent: false,
       },
     };

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -1,9 +1,8 @@
 import { type GetServerSidePropsContext } from "next";
 import { getServerSession } from "next-auth";
+import { isPastDeadline } from "~/lib/date";
 import { authOptions } from "~/server/auth";
 import { db } from "~/server/db";
-
-export const APPLICATION_DEADLINE = new Date("2024-10-16T23:59:00-05:00");
 
 const authRedirect = async (
   context: GetServerSidePropsContext,
@@ -100,8 +99,7 @@ export const notVerifiedRedirect = async (
     };
   }
 
-  const currentDate = Date.now();
-  if (currentDate.valueOf() >= APPLICATION_DEADLINE.valueOf()) {
+  if (isPastDeadline()) {
     return {
       redirect: {
         destination: "/dashboard",


### PR DESCRIPTION
closes #206 

# Quick Overview of Changes

- changed notVerifiedRedirect to redirect to dashboard if the current datetime is after the application deadline (wednesday, october 16 @ 11:59pm)
- remove application button from the dashboard if past the deadline, and add a message for users who submitted an incomplete application

# Checklist

- [x] If any frontend changes were made, include a screenshot/demo in the overview
- [x] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@basokant @ArsalaanAli
