### PR TITLE
test: implement setPassword tests with 40-char token validation

### DIFF
--- a/src/server/api/routers/auth.test.ts
+++ b/src/server/api/routers/auth.test.ts
@@ -299,3 +299,62 @@ describe("auth.resendEmail", () => {
     }
   });
 });
+
+describe("auth.setPassword", () => {
+  test("throw an error if no such token exists", async () => {
+    const nonexistentToken = randomBytes(20).toString("hex"); // 40 characters
+    await expect(
+      caller.auth.setPassword({ password: "HackWestern12!", token: nonexistentToken }),
+    ).rejects.toThrowError("not found");
+  });
+
+  test("throws an error if the token is expired", async () => {
+    const fakeId = faker.string.uuid();
+    const expiredToken = randomBytes(20).toString("hex"); // 40 characters
+
+    const fakeUser = {
+      id: fakeId,
+      name: faker.person.fullName(),
+      email: faker.internet.email(),
+      emailVerified: faker.date.anytime(),
+      image: faker.image.avatar(),
+    };
+
+    await db.insert(users).values(fakeUser);
+
+    await db.insert(resetPasswordTokens).values({
+      userId: fakeId,
+      token: expiredToken, // Use the 40-character token
+      expires: new Date(Date.now() - 1000 * 60 * 60),
+    });
+
+    await expect(
+      caller.auth.setPassword({ password:"HackWestern12!", token: expiredToken }),
+    ).rejects.toThrowError("expired");
+  });
+
+  test("validates the token successfully", async () => {
+    const fakeId = faker.string.uuid();
+    const validToken = randomBytes(20).toString("hex"); // 40 characters
+
+    const fakeUser = {
+      id: fakeId,
+      name: faker.person.fullName(),
+      email: faker.internet.email(),
+      emailVerified: faker.date.anytime(),
+      image: faker.image.avatar(),
+    };
+
+    await db.insert(users).values(fakeUser);
+
+    await db.insert(resetPasswordTokens).values({
+      userId: fakeId,
+      token: validToken, // Use the 40-character token
+      expires: new Date(Date.now() + 1000 * 60 * 60),
+    });
+
+    const result = await caller.auth.setPassword({ password:"HackWestern12!", token: validToken });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/server/api/routers/auth.test.ts
+++ b/src/server/api/routers/auth.test.ts
@@ -304,7 +304,10 @@ describe("auth.setPassword", () => {
   test("throw an error if no such token exists", async () => {
     const nonexistentToken = randomBytes(20).toString("hex"); // 40 characters
     await expect(
-      caller.auth.setPassword({ password: "HackWestern12!", token: nonexistentToken }),
+      caller.auth.setPassword({
+        password: "HackWestern12!",
+        token: nonexistentToken,
+      }),
     ).rejects.toThrowError("not found");
   });
 
@@ -329,7 +332,10 @@ describe("auth.setPassword", () => {
     });
 
     await expect(
-      caller.auth.setPassword({ password:"HackWestern12!", token: expiredToken }),
+      caller.auth.setPassword({
+        password: "HackWestern12!",
+        token: expiredToken,
+      }),
     ).rejects.toThrowError("expired");
   });
 
@@ -353,7 +359,10 @@ describe("auth.setPassword", () => {
       expires: new Date(Date.now() + 1000 * 60 * 60),
     });
 
-    const result = await caller.auth.setPassword({ password:"HackWestern12!", token: validToken });
+    const result = await caller.auth.setPassword({
+      password: "HackWestern12!",
+      token: validToken,
+    });
 
     expect(result.success).toBe(true);
   });


### PR DESCRIPTION
- Add tests for nonexistent token, expired token, and valid token scenarios
- Use randomBytes(20).toString("hex") to generate 40-character tokens matching Zod schema requirements
- TODO: Review and standardize token generation across all auth tests

closes (#295 )

# Checklist
- [x] Check that CI is passing.
- [x] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@hunterchen7 @liuwllm
