### PR TITLE
added quantity feature for prizes

### DIFF
--- a/src/server/api/routers/scavenger-hunt.ts
+++ b/src/server/api/routers/scavenger-hunt.ts
@@ -177,11 +177,11 @@ const redeemPrize = async (
       // Deduct quantity for prizes with quantity
       if (reward.quantity) {
         await tx
-        .update(scavengerHuntRewards)
-        .set({
-          quantity: sql`${scavengerHuntRewards.quantity} - 1`,
-        })
-        .where(eq(scavengerHuntRewards.id, rewardId));      
+          .update(scavengerHuntRewards)
+          .set({
+            quantity: sql`${scavengerHuntRewards.quantity} - 1`,
+          })
+          .where(eq(scavengerHuntRewards.id, rewardId));
       }
 
       // Record that we have redeemed an item


### PR DESCRIPTION
# Issues
- Before we forgot to subtract and check how many more items we have. Now we check if we have any more items and auto subtract one before you can scan a redemption.

# Changes
- Fixed this issue by adding it to the ```redeemPrize()``` function within the existing database transaction
- 
@hunterchen7 @liuwllm
