### PR TITLE
615 add unit tests for reviewgetnextid

### DIFF
--- a/src/server/api/routers/review.test.ts
+++ b/src/server/api/routers/review.test.ts
@@ -11,7 +11,6 @@ import { ReviewSeeder } from "~/server/db/seed/reviewSeeder";
 import { ApplicationSeeder } from "~/server/db/seed/applicationSeeder";
 import { GITHUB_URL, LINKEDIN_URL } from "~/utils/urls";
 import { createEmptyReview } from "~/server/api/routers/review";
-import { ZodNull } from "zod";
 
 const session = await mockOrganizerSession(db);
 const ctx = createInnerTRPCContext({ session });

--- a/src/server/api/routers/review.test.ts
+++ b/src/server/api/routers/review.test.ts
@@ -309,13 +309,6 @@ describe("review.getNextId", () => {
       status: "PENDING_REVIEW",
     };
 
-    otherReview = {
-      ...ReviewSeeder.createRandomWithoutUser(),
-      applicantUserId: newHackerSession.user.id,
-      reviewerUserId: organizerSession.user.id,
-      completed: false,
-      referral: false,
-    };
   });
 
   afterEach(async () => {
@@ -334,29 +327,25 @@ describe("review.getNextId", () => {
   });
 
   test("Returns an in-progress review for the reviewer if one exists and no skipId is passed", async () => {
-    review.completed = true;
 
     await db.insert(applications).values(app);
-    await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
-    await db.insert(reviews).values(otherReview);
 
     const result = await organizerCaller.review.getNextId({ skipId: null });
 
-    expect(result).toBe(newHackerSession.user.id);
+    expect(result).toBe(hackerSession.user.id);
   });
 
   test("Skips the in-progress review when skipId matches it", async () => {
     await db.insert(applications).values(app);
     await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
-    await db.insert(reviews).values(otherReview);
 
     const result = await organizerCaller.review.getNextId({
-      skipId: newHackerSession.user.id,
+      skipId: hackerSession.user.id,
     });
 
-    expect(result).toBe(hackerSession.user.id);
+    expect(result).toBe(newHackerSession.user.id);
   });
 
   test("Does not return applications the reviewer has already completed (no skipId)", async () => {
@@ -365,7 +354,6 @@ describe("review.getNextId", () => {
     await db.insert(applications).values(app);
     await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
-    await db.insert(reviews).values(otherReview);
 
     const result = await organizerCaller.review.getNextId({ skipId: null });
 
@@ -378,7 +366,6 @@ describe("review.getNextId", () => {
     await db.insert(applications).values(app);
     await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
-    await db.insert(reviews).values(otherReview);
 
     const result = await organizerCaller.review.getNextId({ skipId: "null" });
 
@@ -391,7 +378,6 @@ describe("review.getNextId", () => {
     await db.insert(applications).values(app);
     await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
-    await db.insert(reviews).values(otherReview);
 
     const result = await organizerCaller.review.getNextId({ skipId: "null" });
 
@@ -404,7 +390,6 @@ describe("review.getNextId", () => {
     await db.insert(applications).values(app);
     await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
-    await db.insert(reviews).values(otherReview);
 
     const result = await organizerCaller.review.getNextId({ skipId: "null" });
 
@@ -424,7 +409,6 @@ describe("review.getNextId", () => {
     await db.insert(applications).values(app);
     await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
-    await db.insert(reviews).values(otherReview);
     await db.insert(reviews).values(secondReview);
 
     const result = await organizerCaller.review.getNextId({ skipId: "null" });

--- a/src/server/api/routers/review.test.ts
+++ b/src/server/api/routers/review.test.ts
@@ -279,14 +279,14 @@ let otherApp: ReturnType<typeof ApplicationSeeder.createRandomWithoutUser> & {
   userId: string;
 };
 
-describe("review.getNextId", () =>{
+describe("review.getNextId", () => {
   beforeEach(async () => {
     hackerSession = await mockSession(db);
 
     newHackerSession = await mockSession(db);
-    
+
     organizerSession = await mockOrganizerSession(db);
-    organizerCtx = createInnerTRPCContext({ session: organizerSession});
+    organizerCtx = createInnerTRPCContext({ session: organizerSession });
     organizerCaller = createCaller(organizerCtx);
 
     app = {
@@ -340,26 +340,26 @@ describe("review.getNextId", () =>{
     await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
     await db.insert(reviews).values(otherReview);
-    
-    const result = await organizerCaller.review.getNextId({skipId: null}); 
+
+    const result = await organizerCaller.review.getNextId({ skipId: null });
 
     expect(result).toBe(newHackerSession.user.id);
-    
   });
 
-  test("Skips the in-progress review when skipId matches it", async () =>{
+  test("Skips the in-progress review when skipId matches it", async () => {
     await db.insert(applications).values(app);
     await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
     await db.insert(reviews).values(otherReview);
 
-    const result = await organizerCaller.review.getNextId({skipId: newHackerSession.user.id});
+    const result = await organizerCaller.review.getNextId({
+      skipId: newHackerSession.user.id,
+    });
 
     expect(result).toBe(hackerSession.user.id);
+  });
 
-  }); 
-  
-  test("Does not return applications the reviewer has already completed (no skipId)", async() => {
+  test("Does not return applications the reviewer has already completed (no skipId)", async () => {
     review.completed = true;
 
     await db.insert(applications).values(app);
@@ -367,12 +367,12 @@ describe("review.getNextId", () =>{
     await db.insert(reviews).values(review);
     await db.insert(reviews).values(otherReview);
 
-    const result = await organizerCaller.review.getNextId({skipId: null});
+    const result = await organizerCaller.review.getNextId({ skipId: null });
 
     expect(result).toBe(newHackerSession.user.id);
   });
 
-  test("Does not return applications the reviewer has already completed (with skipId)", async() => {
+  test("Does not return applications the reviewer has already completed (with skipId)", async () => {
     review.completed = true;
 
     await db.insert(applications).values(app);
@@ -380,12 +380,12 @@ describe("review.getNextId", () =>{
     await db.insert(reviews).values(review);
     await db.insert(reviews).values(otherReview);
 
-    const result = await organizerCaller.review.getNextId({skipId: "null"});
+    const result = await organizerCaller.review.getNextId({ skipId: "null" });
 
     expect(result).toBe(newHackerSession.user.id);
   });
 
-  test("Does not return applications with status other than PENDING_REVIEW", async() => {
+  test("Does not return applications with status other than PENDING_REVIEW", async () => {
     app.status = "IN_PROGRESS";
 
     await db.insert(applications).values(app);
@@ -393,13 +393,12 @@ describe("review.getNextId", () =>{
     await db.insert(reviews).values(review);
     await db.insert(reviews).values(otherReview);
 
-    const result = await organizerCaller.review.getNextId({skipId: "null"});
+    const result = await organizerCaller.review.getNextId({ skipId: "null" });
 
     expect(result).toBe(newHackerSession.user.id);
-    
   });
 
-  test("Does not return referred applications", async() => {
+  test("Does not return referred applications", async () => {
     review.referral = true;
 
     await db.insert(applications).values(app);
@@ -407,11 +406,11 @@ describe("review.getNextId", () =>{
     await db.insert(reviews).values(review);
     await db.insert(reviews).values(otherReview);
 
-    const result = await organizerCaller.review.getNextId({skipId: "null"});
+    const result = await organizerCaller.review.getNextId({ skipId: "null" });
 
     expect(result).toBe(newHackerSession.user.id);
   });
-  test("Does not return applications that already have REQUIRED_REVIEWS reviews", async() =>{
+  test("Does not return applications that already have REQUIRED_REVIEWS reviews", async () => {
     const newOrganizerSession = await mockOrganizerSession(db);
 
     const secondReview = {
@@ -420,15 +419,15 @@ describe("review.getNextId", () =>{
       reviewerUserId: newOrganizerSession.user.id,
       completed: false,
       referral: false,
-    }
-    
+    };
+
     await db.insert(applications).values(app);
     await db.insert(applications).values(otherApp);
     await db.insert(reviews).values(review);
     await db.insert(reviews).values(otherReview);
     await db.insert(reviews).values(secondReview);
 
-    const result = await organizerCaller.review.getNextId({skipId: "null"});
+    const result = await organizerCaller.review.getNextId({ skipId: "null" });
 
     expect(result).toBe(newHackerSession.user.id);
 
@@ -436,15 +435,14 @@ describe("review.getNextId", () =>{
       .delete(reviews)
       .where(eq(reviews.reviewerUserId, newOrganizerSession.user.id));
     await db.delete(users).where(eq(users.id, newOrganizerSession.user.id));
-    
   });
   test("Throws NOT_FOUND when no application matches", async () => {
     await db.insert(applications).values(app);
     await db.insert(reviews).values(review);
 
-    await expect(organizerCaller.review.getNextId({skipId: hackerSession.user.id})).rejects.toThrowError(
-      "NOT_FOUND"
-    );
+    await expect(
+      organizerCaller.review.getNextId({ skipId: hackerSession.user.id }),
+    ).rejects.toThrowError("NOT_FOUND");
   });
 });
 

--- a/src/server/api/routers/review.test.ts
+++ b/src/server/api/routers/review.test.ts
@@ -308,7 +308,6 @@ describe("review.getNextId", () => {
       userId: newHackerSession.user.id,
       status: "PENDING_REVIEW",
     };
-
   });
 
   afterEach(async () => {
@@ -327,7 +326,6 @@ describe("review.getNextId", () => {
   });
 
   test("Returns an in-progress review for the reviewer if one exists and no skipId is passed", async () => {
-
     await db.insert(applications).values(app);
     await db.insert(reviews).values(review);
 

--- a/src/server/api/routers/review.test.ts
+++ b/src/server/api/routers/review.test.ts
@@ -11,6 +11,7 @@ import { ReviewSeeder } from "~/server/db/seed/reviewSeeder";
 import { ApplicationSeeder } from "~/server/db/seed/applicationSeeder";
 import { GITHUB_URL, LINKEDIN_URL } from "~/utils/urls";
 import { createEmptyReview } from "~/server/api/routers/review";
+import { ZodNull } from "zod";
 
 const session = await mockOrganizerSession(db);
 const ctx = createInnerTRPCContext({ session });
@@ -267,6 +268,184 @@ describe("review.getByOrganizer", () => {
       .delete(applications)
       .where(eq(applications.userId, hackerSession.user.id));
     await db.delete(users).where(eq(users.id, organizerSession.user.id));
+  });
+});
+
+let app: ReturnType<typeof ApplicationSeeder.createRandomWithoutUser> & {
+  userId: string;
+};
+let newHackerSession: Session;
+let otherReview: ReturnType<typeof createRandomReview>;
+let otherApp: ReturnType<typeof ApplicationSeeder.createRandomWithoutUser> & {
+  userId: string;
+};
+
+describe("review.getNextId", () =>{
+  beforeEach(async () => {
+    hackerSession = await mockSession(db);
+
+    newHackerSession = await mockSession(db);
+    
+    organizerSession = await mockOrganizerSession(db);
+    organizerCtx = createInnerTRPCContext({ session: organizerSession});
+    organizerCaller = createCaller(organizerCtx);
+
+    app = {
+      ...ApplicationSeeder.createRandomWithoutUser(),
+      userId: hackerSession.user.id,
+      status: "PENDING_REVIEW",
+    };
+
+    review = {
+      ...ReviewSeeder.createRandomWithoutUser(),
+      applicantUserId: hackerSession.user.id,
+      reviewerUserId: organizerSession.user.id,
+      completed: false,
+      referral: false,
+    };
+
+    otherApp = {
+      ...ApplicationSeeder.createRandomWithoutUser(),
+      userId: newHackerSession.user.id,
+      status: "PENDING_REVIEW",
+    };
+
+    otherReview = {
+      ...ReviewSeeder.createRandomWithoutUser(),
+      applicantUserId: newHackerSession.user.id,
+      reviewerUserId: organizerSession.user.id,
+      completed: false,
+      referral: false,
+    };
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(reviews)
+      .where(eq(reviews.reviewerUserId, organizerSession.user.id));
+    await db
+      .delete(applications)
+      .where(eq(applications.userId, hackerSession.user.id));
+    await db
+      .delete(applications)
+      .where(eq(applications.userId, newHackerSession.user.id));
+    await db.delete(users).where(eq(users.id, organizerSession.user.id));
+    await db.delete(users).where(eq(users.id, hackerSession.user.id));
+    await db.delete(users).where(eq(users.id, newHackerSession.user.id));
+  });
+
+  test("Returns an in-progress review for the reviewer if one exists and no skipId is passed", async () => {
+    review.completed = true;
+
+    await db.insert(applications).values(app);
+    await db.insert(applications).values(otherApp);
+    await db.insert(reviews).values(review);
+    await db.insert(reviews).values(otherReview);
+    
+    const result = await organizerCaller.review.getNextId({skipId: null}); 
+
+    expect(result).toBe(newHackerSession.user.id);
+    
+  });
+
+  test("Skips the in-progress review when skipId matches it", async () =>{
+    await db.insert(applications).values(app);
+    await db.insert(applications).values(otherApp);
+    await db.insert(reviews).values(review);
+    await db.insert(reviews).values(otherReview);
+
+    const result = await organizerCaller.review.getNextId({skipId: newHackerSession.user.id});
+
+    expect(result).toBe(hackerSession.user.id);
+
+  }); 
+  
+  test("Does not return applications the reviewer has already completed (no skipId)", async() => {
+    review.completed = true;
+
+    await db.insert(applications).values(app);
+    await db.insert(applications).values(otherApp);
+    await db.insert(reviews).values(review);
+    await db.insert(reviews).values(otherReview);
+
+    const result = await organizerCaller.review.getNextId({skipId: null});
+
+    expect(result).toBe(newHackerSession.user.id);
+  });
+
+  test("Does not return applications the reviewer has already completed (with skipId)", async() => {
+    review.completed = true;
+
+    await db.insert(applications).values(app);
+    await db.insert(applications).values(otherApp);
+    await db.insert(reviews).values(review);
+    await db.insert(reviews).values(otherReview);
+
+    const result = await organizerCaller.review.getNextId({skipId: "null"});
+
+    expect(result).toBe(newHackerSession.user.id);
+  });
+
+  test("Does not return applications with status other than PENDING_REVIEW", async() => {
+    app.status = "IN_PROGRESS";
+
+    await db.insert(applications).values(app);
+    await db.insert(applications).values(otherApp);
+    await db.insert(reviews).values(review);
+    await db.insert(reviews).values(otherReview);
+
+    const result = await organizerCaller.review.getNextId({skipId: "null"});
+
+    expect(result).toBe(newHackerSession.user.id);
+    
+  });
+
+  test("Does not return referred applications", async() => {
+    review.referral = true;
+
+    await db.insert(applications).values(app);
+    await db.insert(applications).values(otherApp);
+    await db.insert(reviews).values(review);
+    await db.insert(reviews).values(otherReview);
+
+    const result = await organizerCaller.review.getNextId({skipId: "null"});
+
+    expect(result).toBe(newHackerSession.user.id);
+  });
+  test("Does not return applications that already have REQUIRED_REVIEWS reviews", async() =>{
+    const newOrganizerSession = await mockOrganizerSession(db);
+
+    const secondReview = {
+      ...ReviewSeeder.createRandomWithoutUser(),
+      applicantUserId: hackerSession.user.id,
+      reviewerUserId: newOrganizerSession.user.id,
+      completed: false,
+      referral: false,
+    }
+    
+    await db.insert(applications).values(app);
+    await db.insert(applications).values(otherApp);
+    await db.insert(reviews).values(review);
+    await db.insert(reviews).values(otherReview);
+    await db.insert(reviews).values(secondReview);
+
+    const result = await organizerCaller.review.getNextId({skipId: "null"});
+
+    expect(result).toBe(newHackerSession.user.id);
+
+    await db
+      .delete(reviews)
+      .where(eq(reviews.reviewerUserId, newOrganizerSession.user.id));
+    await db.delete(users).where(eq(users.id, newOrganizerSession.user.id));
+    
+  });
+  test("Throws NOT_FOUND when no application matches", async () => {
+    await db.insert(applications).values(app);
+    await db.insert(reviews).values(review);
+
+    await expect(organizerCaller.review.getNextId({skipId: hackerSession.user.id})).rejects.toThrowError(
+      "NOT_FOUND"
+    );
   });
 });
 


### PR DESCRIPTION
closes #615 

# Quick Overview of Changes

- added all tests mentioned in the issue + one extra (testing that it doesn't return already completed reviews when a skipId is passed vs when it is not)
- i created my own `app` variable (for applications) since the other one was linked to a review object type 

# Checklist

- [ ] If any frontend changes were made, include a screenshot/demo in the overview
- [ ] Checked all uses of changed component(s)/function(s)
- [ ] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [ ] Check that CI is passing.
- [ ] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@lucianlavric @JasmineGu2
