### PR TITLE
XP-style toast + button press feel

### DIFF
--- a/src/components/internals/buttonProps.tsx
+++ b/src/components/internals/buttonProps.tsx
@@ -4,6 +4,7 @@ export interface ButtonProps {
   disabled?: boolean;
   isLoading?: boolean;
   onClick?: () => void;
+  onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   size?: "sm" | "lg";
   direction?: "left" | "right";
   className?: string;

--- a/src/components/internals/primary-button.tsx
+++ b/src/components/internals/primary-button.tsx
@@ -13,6 +13,7 @@ export default function PrimaryButton({
   size = "lg",
   direction,
   onClick,
+  onMouseDown,
   className,
 }: ButtonProps) {
   if (isSkeleton)
@@ -27,6 +28,7 @@ export default function PrimaryButton({
         variant="primary"
         isPending={disabled || isLoading}
         onClick={onClick}
+        onMouseDown={onMouseDown}
         size={size}
         className={`${size == "sm" ? "px-[16px] pb-[10px] pt-[7px]" : "px-[18px] pb-[15px] pt-[12px]"} ${className}`}
       >

--- a/src/components/preregistration-form.tsx
+++ b/src/components/preregistration-form.tsx
@@ -124,6 +124,7 @@ export function PreregistrationForm({ className }: PreregistrationFormProps) {
                       size="sm"
                       direction="right"
                       isLoading={isPending}
+                      onMouseDown={(e) => e.preventDefault()}
                       className="h-[35px]"
                     >
                       Submit
@@ -141,12 +142,12 @@ export function PreregistrationForm({ className }: PreregistrationFormProps) {
           <AnimatePresence>
             {showPopup && (
               <motion.div
-                className="fixed left-1/2 top-6 z-50"
+                className="absolute left-1/2 top-6 z-50"
                 style={{ x: "-50%" }}
                 initial={{ opacity: 0, y: "-100%" }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: "-100%" }}
-                transition={{ type: "spring", damping: 22, stiffness: 320 }}
+                transition={{ type: "tween", duration: 0.32, ease: [0.16, 1, 0.3, 1] }}
               >
                 <Window
                   title={

--- a/src/components/preregistration-form.tsx
+++ b/src/components/preregistration-form.tsx
@@ -147,7 +147,11 @@ export function PreregistrationForm({ className }: PreregistrationFormProps) {
                 initial={{ opacity: 0, y: "-100%" }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: "-100%" }}
-                transition={{ type: "tween", duration: 0.32, ease: [0.16, 1, 0.3, 1] }}
+                transition={{
+                  type: "tween",
+                  duration: 0.32,
+                  ease: [0.16, 1, 0.3, 1],
+                }}
               >
                 <Window
                   title={

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -32,7 +32,7 @@ export const buttonVariants = cva(buttonBase, {
     variant: {
       // default: "",
       primary: cn(
-        "bg-gray-2 shadow-button-primary hover:bg-[#CBCBCB] active:bg-gray-2 active:shadow-button-primary-active items-end hover:cursor-pixel-hover",
+        "bg-gray-2 shadow-button-primary hover:bg-[#CBCBCB] active:bg-gray-2 active:shadow-button-primary-active items-end hover:cursor-pixel-hover transition-[background-color,box-shadow] duration-200",
       ),
       secondary: cn(
         "rounded-full bg-offwhite border border-highlight shadow-button-secondary hover:bg-blue-1 hover:border-blue-1 active:bg-light active:border-light text-medium",
@@ -98,9 +98,37 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const lockPressed =
       isPending && (variant === "primary" || variant === "secondary");
 
+    // Keep the button visually sunken for a beat after release, like an XP
+    // button holding its depressed state before springing back.
+    const canHoldPress = variant === "primary" || variant === "secondary";
+    const [held, setHeld] = React.useState(false);
+    const releaseTimer = React.useRef<ReturnType<typeof setTimeout> | null>(
+      null,
+    );
+    React.useEffect(
+      () => () => {
+        if (releaseTimer.current) clearTimeout(releaseTimer.current);
+      },
+      [],
+    );
+    const holdDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (canHoldPress) {
+        if (releaseTimer.current) clearTimeout(releaseTimer.current);
+        setHeld(true);
+      }
+      props.onPointerDown?.(e);
+    };
+    const releaseSoon = () => {
+      if (!canHoldPress) return;
+      if (releaseTimer.current) clearTimeout(releaseTimer.current);
+      releaseTimer.current = setTimeout(() => setHeld(false), 160);
+    };
+    const showPressed = held && canHoldPress && !lockPressed;
+
     const btnClasses = cn(
       buttonVariants({ variant, size, className }),
       lockPressed && [pressedByVariant[variant], noLift],
+      showPressed && pressedByVariant[variant as "primary" | "secondary"],
       full && "w-full",
     );
 
@@ -115,6 +143,15 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         <Comp
           ref={ref}
           {...props}
+          onPointerDown={holdDown}
+          onPointerUp={(e: React.PointerEvent<HTMLButtonElement>) => {
+            releaseSoon();
+            props.onPointerUp?.(e);
+          }}
+          onPointerLeave={(e: React.PointerEvent<HTMLButtonElement>) => {
+            releaseSoon();
+            props.onPointerLeave?.(e);
+          }}
           className={cn(
             "flex items-end",
             (variant === "primary" ||

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -128,7 +128,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const btnClasses = cn(
       buttonVariants({ variant, size, className }),
       lockPressed && [pressedByVariant[variant], noLift],
-      showPressed && pressedByVariant[variant as "primary" | "secondary"],
+      showPressed && pressedByVariant[variant],
       full && "w-full",
     );
 


### PR DESCRIPTION
Polishes the pre-registration form interactions to feel more Windows XP.

## Changes
- **Toast drop-in** — replaced the springy framer-motion bounce with a snappy ease-out slide+fade (`tween`, expo curve `[0.16, 1, 0.3, 1]`, 0.32s), matching how XP system notifications slid in cleanly with no rubber-band.
- **Submit button press** — the button now holds its sunken/pressed state ~160ms after release, then eases back over a 200ms box-shadow transition, recreating the XP tactile "stays depressed" feel. Implemented in the base `Button` for primary/secondary variants.
- **Placeholder flicker fix** — the submit button no longer steals focus on `mousedown` (`onMouseDown` preventDefault), so the "Sign up for updates" placeholder stays hidden while pressing instead of popping back in.
- **Toast position** — now `absolute` at the top.

## Testing
- Verified locally on the landing page (`/`): toast slide+fade, button press linger, and no placeholder flicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)