### PR TITLE
Redirect /sponsors/sponsors.pdf to new shared path

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,17 @@ const config = {
     locales: ["en"],
     defaultLocale: "en",
   },
+
+  async redirects() {
+    return [
+      // sponsors.pdf moved to public/shared/sponsors in #628; old link is in circulation
+      {
+        source: "/sponsors/sponsors.pdf",
+        destination: "/shared/sponsors/sponsors.pdf",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default config;


### PR DESCRIPTION
The public folder cleanup in #628 moved sponsors.pdf to public/shared/sponsors/, breaking the old URL that sponsor emails and decks still link to. Add a permanent redirect so those links keep working.

closes (Github Issue number)

# Quick Overview of Changes

- (added x component)
- (added y function to a service on our backend)

# Checklist

- [ ] If any frontend changes were made, include a screenshot/demo in the overview
- [ ] Checked all uses of changed component(s)/function(s)
- [ ] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [ ] Check that CI is passing.
- [ ] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@lucianlavric @JasmineGu2
