### PR TITLE
Shrink horse telescope popup on mobile

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -106,7 +106,7 @@ export default function Home() {
             aria-hidden="true"
             width={250}
             height={500}
-            className={`absolute bottom-[35px] left-[20px] max-w-[250px] transition-opacity duration-500 ease-in-out ${
+            className={`absolute bottom-[35px] left-[40px] max-w-[70px] transition-opacity duration-500 ease-in-out md:left-[20px] md:max-w-[250px] ${
               horseVisible ? "opacity-100" : "pointer-events-none opacity-0"
             }`}
           />


### PR DESCRIPTION
## What

The click-to-reveal horse popup (`horse.webp`) was fixed at `max-w-[250px]` at every breakpoint, so on phones it took over most of the viewport.

## Changes (mobile-first, desktop unchanged)

- **Mobile:** `max-w-[70px]`, nudged right to `left-[40px]`
- **Desktop (`md:` and up):** restored to original `max-w-[250px]` and `left-[20px]`

Single-line change to `src/pages/index.tsx`; no behavior/logic changes.

## Testing

Verified locally in mobile + desktop viewports via `npm run dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)