### PR TITLE
Internal routing + dashboard + font system (primary/secondary, figtree→pix32)

### DIFF
--- a/src/components/apply/heading.tsx
+++ b/src/components/apply/heading.tsx
@@ -38,7 +38,7 @@ export default function ApplyHeading({
           {heading}
         </h1>
         {subheading && (
-          <h2 className="font-figtree text-sm text-medium">{subheading}</h2>
+          <h2 className="font-secondary text-sm text-medium">{subheading}</h2>
         )}
       </motion.div>
     </AnimatePresence>

--- a/src/components/apply/menu.tsx
+++ b/src/components/apply/menu.tsx
@@ -213,10 +213,10 @@ export function ApplyMenu({ step }: ApplyMenuProps) {
               />
             </Link>
             <div className="gap-2">
-              <h1 className="font-figtree font-bold text-heavy">
+              <h1 className="font-secondary font-bold text-heavy">
                 Application Portal
               </h1>
-              <h2 className="font-figtree font-semibold text-medium">
+              <h2 className="font-secondary font-semibold text-medium">
                 Hack Western 13
               </h2>
             </div>
@@ -254,10 +254,10 @@ export function ApplyMenu({ step }: ApplyMenuProps) {
                     />
                   </Link>
                   <div>
-                    <h1 className="font-figtree text-lg font-bold text-heavy">
+                    <h1 className="font-secondary text-lg font-bold text-heavy">
                       Application Portal
                     </h1>
-                    <h2 className="font-figtree text-sm font-semibold text-medium">
+                    <h2 className="font-secondary text-sm font-semibold text-medium">
                       Hack Western 13
                     </h2>
                   </div>

--- a/src/components/dashboard/ApplicationPrompt.tsx
+++ b/src/components/dashboard/ApplicationPrompt.tsx
@@ -40,7 +40,7 @@ export default function ApplicationPrompt({
         <div>
           <Button
             variant="primary"
-            className="w-full p-6 font-figtree text-base font-medium"
+            className="w-full p-6 font-secondary text-base font-medium"
             onClick={() => void onApplyNavigate(continueStep)}
             disabled={pending}
             aria-busy={pending}

--- a/src/components/dashboard/CharacterIcon.tsx
+++ b/src/components/dashboard/CharacterIcon.tsx
@@ -45,20 +45,20 @@ export default function CharacterIcon() {
           )}
         </button>
       </PopoverTrigger>
-      <PopoverContent className="mr-4 mt-2 w-48 bg-offwhite p-4 font-figtree">
+      <PopoverContent className="mr-4 mt-2 w-48 bg-offwhite p-4 font-secondary">
         <div className="rounded-md">
           <h3 className="mb-3 text-sm font-medium text-medium">
             {name == "Username" ? "Hello, hacker" : `Hi, ${name}`}!
           </h3>
           <div className="mb-4 h-px w-full bg-violet-200" />
 
-          <div className="mb-3 font-figtree text-heavy">
+          <div className="mb-3 font-secondary text-heavy">
             <Link href="/dashboard">Home</Link>
           </div>
 
           <div>
             <button
-              className="font-figtree text-sm text-heavy underline"
+              className="font-secondary text-sm text-heavy underline"
               onClick={() => void signOut()}
             >
               Sign Out

--- a/src/components/dashboard/SubmittedDisplay.tsx
+++ b/src/components/dashboard/SubmittedDisplay.tsx
@@ -84,11 +84,11 @@ export default function SubmittedDisplay({
         <h2 className="font-dico max-w-xl text-4xl font-semibold text-heavy">
           Your application has been submitted!
         </h2>
-        <h4 className="font-figtree text-heavy">
+        <h4 className="font-secondary text-heavy">
           Thanks for applying to <b>Hack Western XIII</b>,{" "}
           {application?.firstName}!
         </h4>
-        <p className="font-figtree text-heavy">
+        <p className="font-secondary text-heavy">
           You&apos;ll hear back from us about your status in a few weeks!
         </p>
         <div>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,6 +1,6 @@
 export function Footer() {
   return (
-    <footer className="absolute bottom-3 z-[100] flex w-full items-center justify-center font-figtree text-sm text-heavy hover:text-medium sm:text-base md:bottom-2 md:right-4 md:block md:w-auto">
+    <footer className="absolute bottom-3 z-[100] flex w-full items-center justify-center font-secondary text-sm text-heavy hover:text-medium sm:text-base md:bottom-2 md:right-4 md:block md:w-auto">
       <a
         href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf"
         target="_blank"

--- a/src/components/live/construction.tsx
+++ b/src/components/live/construction.tsx
@@ -5,7 +5,7 @@ const Construction = () => {
         <p className="font-jetbrains-mono text-lg text-heavy">
           THIS PAGE IS UNDER CONSTRUCTION!
         </p>
-        <p className="font-figtree text-lg text-medium">
+        <p className="font-secondary text-lg text-medium">
           Please check again soon! :&#41;
         </p>
       </div>

--- a/src/components/live/day-schedule.tsx
+++ b/src/components/live/day-schedule.tsx
@@ -47,11 +47,11 @@ const EventBlock = ({ event, type, height }: EventBlockProps) => {
       className={`rounded-lg border-2 p-1.5 sm:p-2.5 ${colorMap[type]} ${textColorMap[type]} absolute left-0 right-0 top-0 z-50 flex select-text flex-col justify-center shadow-sm transition-shadow hover:shadow-md`}
       style={{ height: `${height}px` }}
     >
-      <div className="select-text font-figtree text-[9px] font-semibold leading-tight sm:text-[11px]">
+      <div className="select-text font-secondary text-[9px] font-semibold leading-tight sm:text-[11px]">
         {event.title}
       </div>
       {event.location && (
-        <div className="mt-0.5 select-text font-figtree text-[8px] italic opacity-70 sm:text-[9px]">
+        <div className="mt-0.5 select-text font-secondary text-[8px] italic opacity-70 sm:text-[9px]">
           {event.location}
         </div>
       )}
@@ -275,7 +275,7 @@ const DayScheduleView = ({ day, events }: DayScheduleProps) => {
     <div className="w-full pb-3 sm:pb-4">
       <div className="rounded-sm px-3 py-4 sm:p-6">
         {/* Header with day name */}
-        <div className="sticky left-0 mb-3 mt-1 font-figtree text-lg font-bold text-heavy sm:mb-4 sm:mt-2 sm:text-2xl">
+        <div className="sticky left-0 mb-3 mt-1 font-secondary text-lg font-bold text-heavy sm:mb-4 sm:mt-2 sm:text-2xl">
           {day}, November{" "}
           {day === "Friday" ? "21st" : day === "Saturday" ? "22nd" : "23rd"}
         </div>
@@ -400,7 +400,7 @@ const DayScheduleView = ({ day, events }: DayScheduleProps) => {
                   }}
                 >
                   {/* Time label */}
-                  <div className="font-base flex items-start pt-1.5 font-figtree text-[10px] text-medium sm:pt-2 sm:text-xs">
+                  <div className="font-base flex items-start pt-1.5 font-secondary text-[10px] text-medium sm:pt-2 sm:text-xs">
                     {event.time}
                   </div>
 

--- a/src/components/live/event-logistics.tsx
+++ b/src/components/live/event-logistics.tsx
@@ -113,7 +113,7 @@ const EventLogistics = () => {
           <div className="flex flex-col">
             <div className="flex flex-row items-center gap-2">
               <LogisticsTopbar />
-              <p className="font-figtree text-light">
+              <p className="font-secondary text-light">
                 Page {step} of {allTitles.length.toString()}
               </p>
             </div>
@@ -165,11 +165,11 @@ const EventLogistics = () => {
                       handleToggle(item.id, checked)
                     }
                   />
-                  <h1 className="-mt-1 font-figtree text-lg text-heavy">
+                  <h1 className="-mt-1 font-secondary text-lg text-heavy">
                     {item.heading}
                   </h1>
                 </div>
-                <p className="pl-7 font-figtree text-medium">{item.desc}</p>
+                <p className="pl-7 font-secondary text-medium">{item.desc}</p>
               </div>
             );
           })
@@ -178,13 +178,13 @@ const EventLogistics = () => {
             components={{
               h1: ({ node: _node, ...props }) => (
                 <h1
-                  className="mb-4 mt-8 font-figtree text-2xl font-medium text-heavy"
+                  className="mb-4 mt-8 font-secondary text-2xl font-medium text-heavy"
                   {...props}
                 />
               ),
               p: ({ node: _node, ...props }) => (
                 <p
-                  className="mb-4 font-figtree leading-relaxed text-medium"
+                  className="mb-4 font-secondary leading-relaxed text-medium"
                   {...props}
                 />
               ),
@@ -198,25 +198,25 @@ const EventLogistics = () => {
               ),
               b: ({ node: _node, ...props }) => (
                 <b
-                  className="mb-4 font-figtree font-bold leading-relaxed text-medium"
+                  className="mb-4 font-secondary font-bold leading-relaxed text-medium"
                   {...props}
                 />
               ),
               i: ({ node: _node, ...props }) => (
                 <i
-                  className="font-italic mb-4 font-figtree leading-relaxed text-medium"
+                  className="font-italic mb-4 font-secondary leading-relaxed text-medium"
                   {...props}
                 />
               ),
               ul: ({ node: _node, ...props }) => (
                 <ul
-                  className="mb-4 list-disc space-y-1 pl-6 font-figtree text-medium"
+                  className="mb-4 list-disc space-y-1 pl-6 font-secondary text-medium"
                   {...props}
                 />
               ),
               ol: ({ node: _node, ...props }) => (
                 <ol
-                  className="mb-4 list-decimal space-y-1 pl-6 font-figtree text-medium"
+                  className="mb-4 list-decimal space-y-1 pl-6 font-secondary text-medium"
                   {...props}
                 />
               ),

--- a/src/components/live/food-menu.tsx
+++ b/src/components/live/food-menu.tsx
@@ -91,10 +91,10 @@ const FoodMenu = () => {
                               >
                                 <div className="flex flex-row items-start justify-between">
                                   <div className="flex flex-col justify-center">
-                                    <h2 className="font-figtree font-medium text-heavy">
+                                    <h2 className="font-secondary font-medium text-heavy">
                                       {option.name}
                                     </h2>
-                                    <h3 className="font-italic font-figtree text-medium">
+                                    <h3 className="font-italic font-secondary text-medium">
                                       {option.vendor}
                                     </h3>
                                   </div>
@@ -104,7 +104,7 @@ const FoodMenu = () => {
                                       onClick={() =>
                                         toggleAllergens(allergenKey)
                                       }
-                                      className={`flex flex-row items-center gap-2 rounded-md px-2 py-1 font-figtree text-sm font-medium transition-colors ${
+                                      className={`flex flex-row items-center gap-2 rounded-md px-2 py-1 font-secondary text-sm font-medium transition-colors ${
                                         isExpanded
                                           ? "bg-primary-300 text-heavy"
                                           : "bg-highlight text-medium"
@@ -120,7 +120,7 @@ const FoodMenu = () => {
                                     <div className="overflow-x-auto">
                                       <Table>
                                         <TableHeader>
-                                          <TableRow className="font-figtree text-heavy">
+                                          <TableRow className="font-secondary text-heavy">
                                             {(
                                               Object.keys(
                                                 option.allergens,

--- a/src/components/live/home.tsx
+++ b/src/components/live/home.tsx
@@ -101,7 +101,7 @@ const Home = () => {
   if (!session) {
     return (
       <div className="flex min-h-[400px] w-full flex-col items-center justify-center gap-4">
-        <h2 className="font-figtree text-2xl font-semibold text-heavy">
+        <h2 className="font-secondary text-2xl font-semibold text-heavy">
           Sign In Required
         </h2>
         <p className="text-center text-medium">
@@ -109,7 +109,7 @@ const Home = () => {
         </p>
         <button
           onClick={() => signIn(undefined, { callbackUrl: "/live?tab=home" })}
-          className="rounded-lg bg-primary-600 px-6 py-3 font-figtree text-sm font-medium text-white transition-colors hover:bg-primary-700"
+          className="rounded-lg bg-primary-600 px-6 py-3 font-secondary text-sm font-medium text-white transition-colors hover:bg-primary-700"
         >
           Sign In
         </button>
@@ -123,7 +123,7 @@ const Home = () => {
       <div className="flex w-full flex-col gap-6 lg:w-1/2">
         {/* Devpost Link Section */}
         <div className="rounded-2xl bg-primary-100 p-6">
-          <h2 className="mb-4 font-figtree text-xl font-semibold text-heavy">
+          <h2 className="mb-4 font-secondary text-xl font-semibold text-heavy">
             Devpost Link
           </h2>
           <a
@@ -147,7 +147,7 @@ const Home = () => {
                     d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
                   />
                 </svg>
-                <span className="font-figtree text-sm font-medium text-heavy">
+                <span className="font-secondary text-sm font-medium text-heavy">
                   hack-western-12.devpost.com
                 </span>
               </div>
@@ -170,7 +170,7 @@ const Home = () => {
 
         {/* Scan History Section */}
         <div className="rounded-2xl bg-primary-100 p-6">
-          <h2 className="mb-4 font-figtree text-xl font-semibold text-heavy">
+          <h2 className="mb-4 font-secondary text-xl font-semibold text-heavy">
             Scan History
           </h2>
 
@@ -178,7 +178,7 @@ const Home = () => {
           <div className="mb-4 flex gap-2">
             <button
               onClick={() => setActiveTab("all")}
-              className={`rounded-lg px-4 py-2 font-figtree text-sm font-medium transition-colors ${
+              className={`rounded-lg px-4 py-2 font-secondary text-sm font-medium transition-colors ${
                 activeTab === "all"
                   ? "bg-primary-600 text-white"
                   : "bg-primary-200 text-heavy hover:bg-primary-300"
@@ -188,7 +188,7 @@ const Home = () => {
             </button>
             <button
               onClick={() => setActiveTab("activities")}
-              className={`rounded-lg px-4 py-2 font-figtree text-sm font-medium transition-colors ${
+              className={`rounded-lg px-4 py-2 font-secondary text-sm font-medium transition-colors ${
                 activeTab === "activities"
                   ? "bg-primary-600 text-white"
                   : "bg-primary-200 text-heavy hover:bg-primary-300"
@@ -198,7 +198,7 @@ const Home = () => {
             </button>
             <button
               onClick={() => setActiveTab("meals")}
-              className={`rounded-lg px-4 py-2 font-figtree text-sm font-medium transition-colors ${
+              className={`rounded-lg px-4 py-2 font-secondary text-sm font-medium transition-colors ${
                 activeTab === "meals"
                   ? "bg-primary-600 text-white"
                   : "bg-primary-200 text-heavy hover:bg-primary-300"
@@ -208,7 +208,7 @@ const Home = () => {
             </button>
             <button
               onClick={() => setActiveTab("redemptions")}
-              className={`rounded-lg px-4 py-2 font-figtree text-sm font-medium transition-colors ${
+              className={`rounded-lg px-4 py-2 font-secondary text-sm font-medium transition-colors ${
                 activeTab === "redemptions"
                   ? "bg-primary-600 text-white"
                   : "bg-primary-200 text-heavy hover:bg-primary-300"
@@ -221,7 +221,7 @@ const Home = () => {
           {/* Content */}
           <div className="rounded-xl bg-primary-50 p-4">
             {scansLoading ? (
-              <p className="font-figtree text-sm text-medium">Loading...</p>
+              <p className="font-secondary text-sm text-medium">Loading...</p>
             ) : filteredScans && filteredScans.length > 0 ? (
               <div className="space-y-3">
                 {filteredScans.map((scan) => (
@@ -230,10 +230,10 @@ const Home = () => {
                     className="flex items-center justify-between rounded-lg bg-white p-3 shadow-sm"
                   >
                     <div className="flex-1">
-                      <p className="font-figtree text-sm font-semibold text-heavy">
+                      <p className="font-secondary text-sm font-semibold text-heavy">
                         {formatTitle(scan.itemDescription ?? scan.itemCode)}
                       </p>
-                      <p className="font-figtree text-xs text-medium">
+                      <p className="font-secondary text-xs text-medium">
                         {scan.createdAt
                           ? new Date(scan.createdAt).toLocaleString("en-US", {
                               month: "short",
@@ -246,7 +246,7 @@ const Home = () => {
                     </div>
                     <div className="ml-4 text-right">
                       <p
-                        className={`font-figtree text-sm font-semibold ${
+                        className={`font-secondary text-sm font-semibold ${
                           scan.points < 0 ? "text-red-600" : "text-primary-600"
                         }`}
                       >
@@ -258,7 +258,7 @@ const Home = () => {
                 ))}
               </div>
             ) : (
-              <p className="font-figtree text-sm italic text-medium">
+              <p className="font-secondary text-sm italic text-medium">
                 {activeTab === "all"
                   ? "You haven't scanned any activities yet!"
                   : activeTab === "meals"
@@ -276,29 +276,29 @@ const Home = () => {
       <div className="flex w-full flex-col gap-6 pb-4 lg:w-1/2">
         {/* Points Section */}
         <div className="rounded-2xl bg-primary-100 p-6">
-          <h2 className="mb-4 font-figtree text-xl font-semibold text-heavy">
+          <h2 className="mb-4 font-secondary text-xl font-semibold text-heavy">
             Your Points
           </h2>
           <div className="rounded-xl bg-primary-50 p-4">
             {pointsLoading ? (
-              <p className="font-figtree text-sm text-medium">Loading...</p>
+              <p className="font-secondary text-sm text-medium">Loading...</p>
             ) : (
               <div className="space-y-2">
                 <div className="flex items-baseline justify-between">
-                  <p className="font-figtree text-sm text-medium">
+                  <p className="font-secondary text-sm text-medium">
                     Current Balance:
                   </p>
-                  <p className="font-figtree text-2xl font-bold text-primary-600">
+                  <p className="font-secondary text-2xl font-bold text-primary-600">
                     {pointsData?.balance ?? 0}
                   </p>
                 </div>
                 {pointsData?.earned !== null &&
                   pointsData?.earned !== undefined && (
                     <div className="flex items-baseline justify-between border-t border-primary-200 pt-2">
-                      <p className="font-figtree text-xs text-medium">
+                      <p className="font-secondary text-xs text-medium">
                         Total Earned:
                       </p>
-                      <p className="font-figtree text-sm font-medium text-medium">
+                      <p className="font-secondary text-sm font-medium text-medium">
                         {pointsData.earned} pts
                       </p>
                     </div>
@@ -319,10 +319,10 @@ const Home = () => {
                 </div>
               ) : !isApproved ? (
                 <div className="flex h-[300px] w-[300px] flex-col items-center justify-center gap-2 bg-gray-100 p-6 text-center">
-                  <p className="font-figtree text-sm font-semibold text-heavy">
+                  <p className="font-secondary text-sm font-semibold text-heavy">
                     Hacker pass unavailable
                   </p>
-                  <p className="font-figtree text-xs text-medium">
+                  <p className="font-secondary text-xs text-medium">
                     Your hacker pass will appear here once your application has
                     been accepted.
                   </p>

--- a/src/components/live/map.tsx
+++ b/src/components/live/map.tsx
@@ -15,10 +15,10 @@ const Map = () => {
   return (
     <div className="flex h-screen flex-col gap-4">
       <div className="flex flex-col gap-2">
-        <p className="font-figtree text-base text-medium">
+        <p className="font-secondary text-base text-medium">
           This year&apos;s venue will be at Somerville House & Thames Hall!
         </p>
-        <p className="font-figtree text-base text-medium">
+        <p className="font-secondary text-base text-medium">
           <b className="text-heavy">Address:</b> 40 Lambton Dr, London, ON N6G
           2V4
         </p>
@@ -29,7 +29,7 @@ const Map = () => {
             <TabsTrigger value="Floor 2">Floor 2 Map</TabsTrigger>
             <TabsTrigger value="Floor 3">Floor 3 Map</TabsTrigger>
           </TabsList>
-          <p className="font-figtree text-sm text-medium">
+          <p className="font-secondary text-sm text-medium">
             {isMobile
               ? "* View the map below"
               : "* Zoom in and out of the map by scrolling!"}

--- a/src/components/live/mentors.tsx
+++ b/src/components/live/mentors.tsx
@@ -20,7 +20,7 @@ const Mentors = () => {
       {haveAllMentors ? (
         <div className="mb-6 px-6">
           <div className="my-8 md:flex md:flex-col">
-            <div className="py-1 font-figtree font-medium text-heavy">
+            <div className="py-1 font-secondary font-medium text-heavy">
               Filter by:
             </div>
             <div className="flex flex-wrap gap-3">
@@ -31,7 +31,7 @@ const Mentors = () => {
                     selectedMentorTags.includes(tag)
                       ? "bg-heavy font-medium text-[#ebdff7]"
                       : "bg-[#ebdff7] font-medium text-medium"
-                  } font-figtree transition-all hover:bg-heavy hover:text-[#ebdff7]`}
+                  } font-secondary transition-all hover:bg-heavy hover:text-[#ebdff7]`}
                   onClick={() => {
                     setSelectedMentorTags((prev) =>
                       prev.includes(tag)
@@ -89,10 +89,10 @@ const MentorCard = (mentor: Mentor) => {
         )}
       </div>
       <div className="my-2">
-        <h2 className="font-figtree text-lg font-medium text-heavy">
+        <h2 className="font-secondary text-lg font-medium text-heavy">
           {mentor.name}
         </h2>
-        <p className="font-figtree text-base text-[#64748B] text-medium">
+        <p className="font-secondary text-base text-[#64748B] text-medium">
           {mentor.desc}
         </p>
       </div>
@@ -101,7 +101,7 @@ const MentorCard = (mentor: Mentor) => {
         {mentor.tags.map((tag) => (
           <span
             key={tag}
-            className="rounded-lg bg-primary-300 p-1 px-2 font-figtree font-medium text-medium"
+            className="rounded-lg bg-primary-300 p-1 px-2 font-secondary font-medium text-medium"
           >
             {tag}
           </span>

--- a/src/components/live/navlinks.tsx
+++ b/src/components/live/navlinks.tsx
@@ -9,7 +9,7 @@ export const SectionLink = ({ tab, name }: { tab: string; name: string }) => {
   return (
     <Link
       href={`live/?tab=${tab}`}
-      className={`flex items-center gap-3 px-4 py-1.5 py-3 font-figtree ${isActive ? "bg-primary-300 text-heavy" : "text-medium"} rounded-md transition-all hover:bg-primary-300`}
+      className={`flex items-center gap-3 px-4 py-1.5 py-3 font-secondary ${isActive ? "bg-primary-300 text-heavy" : "text-medium"} rounded-md transition-all hover:bg-primary-300`}
     >
       <SidebarIcon icon={tab} selected={isActive} />
       <div className="flex flex-col justify-center font-medium">{name}</div>
@@ -34,14 +34,14 @@ export const IconlessLink = ({ tab, name }: { tab: string; name: string }) => {
       {eventLogisticsTab || miscLogisticsTab ? (
         <Link
           href={`live/?tab=event-logistics&step=${step}`}
-          className={`flex gap-3 px-4 py-3 font-figtree ${isActive ? "bg-primary-300 text-heavy" : "text-medium"} rounded-md transition-all hover:bg-primary-300`}
+          className={`flex gap-3 px-4 py-3 font-secondary ${isActive ? "bg-primary-300 text-heavy" : "text-medium"} rounded-md transition-all hover:bg-primary-300`}
         >
           <div className="flex flex-col justify-center font-medium">{name}</div>
         </Link>
       ) : (
         <Link
           href={`live/?tab=${tab}`}
-          className={`flex gap-3 px-4 py-3 font-figtree ${isActive ? "bg-primary-300 text-heavy" : "text-medium"} rounded-md transition-all hover:bg-primary-300`}
+          className={`flex gap-3 px-4 py-3 font-secondary ${isActive ? "bg-primary-300 text-heavy" : "text-medium"} rounded-md transition-all hover:bg-primary-300`}
         >
           <div className="flex flex-col justify-center font-medium">{name}</div>
         </Link>
@@ -63,7 +63,7 @@ export const LogisticsLink = ({
   return (
     <Link
       href={`live/?tab=event-logistics&step=${step}`}
-      className={`flex w-full items-center gap-3 px-4 py-2.5 font-figtree ${isActive ? "bg-primary-300 text-heavy" : "text-medium"} rounded-md transition-all hover:bg-primary-300`}
+      className={`flex w-full items-center gap-3 px-4 py-2.5 font-secondary ${isActive ? "bg-primary-300 text-heavy" : "text-medium"} rounded-md transition-all hover:bg-primary-300`}
     >
       <LogisticsIcon icon={step} selected={isActive} />
       <div className="font-medium">{name}</div>

--- a/src/components/live/schedule.tsx
+++ b/src/components/live/schedule.tsx
@@ -78,7 +78,7 @@ const Schedule = () => {
       </div>
 
       {scheduleData.length === 0 && (
-        <div className="py-10 text-center font-figtree text-medium">
+        <div className="py-10 text-center font-secondary text-medium">
           No schedule data available
         </div>
       )}

--- a/src/components/live/sidebar.tsx
+++ b/src/components/live/sidebar.tsx
@@ -21,7 +21,7 @@ const Sidebar = () => {
     <div className="hidden h-screen w-1/4 flex-col justify-between bg-highlight px-4 py-8 md:flex lg:px-6 2xl:w-1/5 2xl:px-8 3xl:w-1/6 3xl:px-12">
       <div>
         <Link
-          className="py-auto flex gap-4 text-center font-figtree text-lg font-bold text-heavy lg:text-xl"
+          className="py-auto flex gap-4 text-center font-secondary text-lg font-bold text-heavy lg:text-xl"
           href="/"
         >
           <Horsey />

--- a/src/components/live/sponsors.tsx
+++ b/src/components/live/sponsors.tsx
@@ -87,7 +87,7 @@ const SponsorCard = ({
           >
             <div className="mx-8 border-t border-gray-100 py-4">
               <p
-                className={`whitespace-pre-line font-figtree ${textSize} leading-relaxed text-medium`}
+                className={`whitespace-pre-line font-secondary ${textSize} leading-relaxed text-medium`}
               >
                 {description}
               </p>
@@ -104,7 +104,7 @@ const Sponsors = () => {
     <div className="h-full overflow-auto p-8 md:p-12">
       {/* Thank you text */}
       <div className="mb-12 text-center">
-        <p className="font-figtree text-medium md:text-lg">
+        <p className="font-secondary text-medium md:text-lg">
           {SPONSOR_THANK_YOU_TEXT}
         </p>
       </div>
@@ -141,7 +141,7 @@ const Sponsors = () => {
         return (
           <div key={tier.tier} className="mb-12">
             <h2
-              className={`mb-6 text-center font-figtree ${config.titleSize} font-semibold text-heavy`}
+              className={`mb-6 text-center font-secondary ${config.titleSize} font-semibold text-heavy`}
             >
               {tier.tier}
             </h2>

--- a/src/components/preregistration-form.tsx
+++ b/src/components/preregistration-form.tsx
@@ -164,7 +164,7 @@ export function PreregistrationForm({ className }: PreregistrationFormProps) {
                     if (min) setShowPopup(false);
                   }}
                 >
-                  <p className="px-4 text-center font-figtree text-sm font-medium text-heavy">
+                  <p className="px-4 text-center font-secondary text-sm font-medium text-heavy">
                     {popupMessage}
                   </p>
                 </Window>

--- a/src/components/scan.tsx
+++ b/src/components/scan.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/router";
 import { api } from "~/utils/api";
+import SecondaryButton from "~/components/internals/secondary-button";
 
 interface Activity {
   id: number;
@@ -63,21 +64,18 @@ const Scan = () => {
   };
 
   return (
-    <div
-      className="flex min-h-screen flex-col"
-      style={{ backgroundColor: "#f5f2f6" }}
-    >
+    <div className="flex min-h-screen flex-col bg-highlight">
       {/* Header */}
       <header className="flex items-center justify-between p-4">
         <div></div>
-        <button
+        <SecondaryButton
+          size="sm"
           onClick={() => {
             void router.push("/scavenger/redeem");
           }}
-          className="rounded-lg bg-white px-4 py-2 font-figtree font-medium text-heavy shadow-md transition-colors hover:bg-violet-100 active:bg-violet-200"
         >
           Redeem Points
-        </button>
+        </SecondaryButton>
       </header>
 
       {/* Main Content */}
@@ -109,7 +107,7 @@ const Scan = () => {
                   <button
                     key={item.id}
                     onClick={() => handleActivityClick(item.id)}
-                    className="w-full rounded-lg bg-white px-4 py-3 text-left font-figtree font-semibold text-heavy shadow-md transition-colors hover:bg-violet-100 active:bg-violet-200"
+                    className="w-full rounded-lg bg-offwhite px-4 py-3 text-left font-figtree font-semibold text-heavy shadow-md transition-colors hover:bg-blue-1 active:bg-blue-2"
                   >
                     {item.description ?? item.code}
                   </button>

--- a/src/components/scan.tsx
+++ b/src/components/scan.tsx
@@ -80,18 +80,18 @@ const Scan = () => {
 
       {/* Main Content */}
       <main className="w-full flex-1 space-y-6 p-6">
-        <h1 className="font-dico text-left text-3xl font-medium text-heavy">
+        <h1 className="text-left font-main text-3xl font-medium text-heavy">
           Select activity to scan
         </h1>
 
         {isLoading && (
-          <div className="text-center font-figtree text-medium">
+          <div className="text-center font-secondary text-medium">
             Loading activities...
           </div>
         )}
 
         {!isLoading && categories.length === 0 && (
-          <div className="text-center font-figtree text-medium">
+          <div className="text-center font-secondary text-medium">
             No activities found
           </div>
         )}
@@ -99,7 +99,7 @@ const Scan = () => {
         {!isLoading &&
           categories.map((category) => (
             <section key={category.title} className="space-y-4">
-              <h3 className="font-figtree text-base font-medium text-medium">
+              <h3 className="font-secondary text-base font-medium text-medium">
                 {category.title}
               </h3>
               <div className="space-y-2">
@@ -107,7 +107,7 @@ const Scan = () => {
                   <button
                     key={item.id}
                     onClick={() => handleActivityClick(item.id)}
-                    className="w-full rounded-lg bg-offwhite px-4 py-3 text-left font-figtree font-semibold text-heavy shadow-md transition-colors hover:bg-blue-1 active:bg-blue-2"
+                    className="w-full rounded-lg bg-offwhite px-4 py-3 text-left font-secondary font-semibold text-heavy shadow-md transition-colors hover:bg-blue-1 active:bg-blue-2"
                   >
                     {item.description ?? item.code}
                   </button>

--- a/src/components/scan.tsx
+++ b/src/components/scan.tsx
@@ -80,7 +80,7 @@ const Scan = () => {
 
       {/* Main Content */}
       <main className="w-full flex-1 space-y-6 p-6">
-        <h1 className="text-left font-main text-3xl font-medium text-heavy">
+        <h1 className="text-left font-primary text-3xl font-medium text-heavy">
           Select activity to scan
         </h1>
 

--- a/src/components/scans/scans-table.tsx
+++ b/src/components/scans/scans-table.tsx
@@ -18,14 +18,14 @@ export const scansColumns: ColumnDef<ScanRow>[] = [
     accessorKey: "hackerName",
     header: () => (
       <div
-        className="font-figtree text-xs font-medium uppercase tracking-wider"
+        className="font-secondary text-xs font-medium uppercase tracking-wider"
         style={{ color: "#dcd8de" }}
       >
         HACKER NAME
       </div>
     ),
     cell: ({ row }) => (
-      <div className="font-figtree text-sm font-bold text-heavy">
+      <div className="font-secondary text-sm font-bold text-heavy">
         {row.getValue("hackerName")}
       </div>
     ),
@@ -34,14 +34,14 @@ export const scansColumns: ColumnDef<ScanRow>[] = [
     accessorKey: "event",
     header: () => (
       <div
-        className="font-figtree text-xs font-medium uppercase tracking-wider"
+        className="font-secondary text-xs font-medium uppercase tracking-wider"
         style={{ color: "#dcd8de" }}
       >
         EVENT
       </div>
     ),
     cell: ({ row }) => (
-      <div className="font-figtree text-sm font-bold text-heavy">
+      <div className="font-secondary text-sm font-bold text-heavy">
         {row.getValue("event")}
       </div>
     ),
@@ -50,14 +50,14 @@ export const scansColumns: ColumnDef<ScanRow>[] = [
     accessorKey: "scanner",
     header: () => (
       <div
-        className="font-figtree text-xs font-medium uppercase tracking-wider"
+        className="font-secondary text-xs font-medium uppercase tracking-wider"
         style={{ color: "#dcd8de" }}
       >
         SCANNER
       </div>
     ),
     cell: ({ row }) => (
-      <div className="font-figtree text-sm text-heavy">
+      <div className="font-secondary text-sm text-heavy">
         {row.getValue("scanner")}
       </div>
     ),
@@ -66,14 +66,14 @@ export const scansColumns: ColumnDef<ScanRow>[] = [
     accessorKey: "day",
     header: () => (
       <div
-        className="font-figtree text-xs font-medium uppercase tracking-wider"
+        className="font-secondary text-xs font-medium uppercase tracking-wider"
         style={{ color: "#dcd8de" }}
       >
         DAY
       </div>
     ),
     cell: ({ row }) => (
-      <div className="font-figtree text-sm text-heavy">
+      <div className="font-secondary text-sm text-heavy">
         {row.getValue("day")}
       </div>
     ),
@@ -82,14 +82,14 @@ export const scansColumns: ColumnDef<ScanRow>[] = [
     accessorKey: "time",
     header: () => (
       <div
-        className="font-figtree text-xs font-medium uppercase tracking-wider"
+        className="font-secondary text-xs font-medium uppercase tracking-wider"
         style={{ color: "#dcd8de" }}
       >
         TIME
       </div>
     ),
     cell: ({ row }) => (
-      <div className="font-figtree text-sm text-heavy">
+      <div className="font-secondary text-sm text-heavy">
         {row.getValue("time")}
       </div>
     ),
@@ -105,7 +105,7 @@ export function ScansTable({ scans, isLoading }: ScansTableProps) {
   if (isLoading) {
     return (
       <div className="rounded-lg bg-white p-8 shadow-md">
-        <div className="text-center font-figtree text-medium">
+        <div className="text-center font-secondary text-medium">
           Loading scans...
         </div>
       </div>
@@ -115,7 +115,7 @@ export function ScansTable({ scans, isLoading }: ScansTableProps) {
   if (scans.length === 0) {
     return (
       <div className="rounded-lg bg-white p-8 shadow-md">
-        <div className="text-center font-figtree text-medium">
+        <div className="text-center font-secondary text-medium">
           No scans found
         </div>
       </div>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ export interface InputProps
 const inputVariants = cva(
   cn(
     "flex w-full relative bg-white px-[8px] py-[8px] outline-none",
-    `font-figtree font-medium text-[16px] leading-normal`,
+    `font-secondary font-medium text-[16px] leading-normal`,
     `text-gray-6`,
     `placeholder:text-gray-3`,
     "disabled:cursor-not-allowed disabled:opacity-50",

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border border-[#f1f0f2] bg-white p-4 font-figtree text-medium outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 rounded-md border border-[#f1f0f2] bg-white p-4 font-secondary text-medium outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-12  w-fit items-center justify-center rounded-lg bg-highlight p-1 font-figtree",
+      "inline-flex h-12  w-fit items-center justify-center rounded-lg bg-highlight p-1 font-secondary",
       className,
     )}
     {...props}

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -54,8 +54,10 @@ export const fonts = {
   pix32: "var(--font-pix32)",
   // Semantic aliases — repoint these two when the yearly theme fonts change,
   // and everything using font-main / font-secondary carries over automatically.
+  // This year: main = CossetteTexte (display), secondary = Pix32 (body/UI).
+  // figtree is deprecated (last year's font) and being migrated out — see #794.
   main: "var(--font-cossetteTexte)",
-  secondary: "var(--font-figtree)",
+  secondary: "var(--font-pix32)",
 } as const;
 
 // ------------------------------------------------------------

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -53,10 +53,10 @@ export const fonts = {
   figtree: "var(--font-figtree)",
   pix32: "var(--font-pix32)",
   // Semantic aliases — repoint these two when the yearly theme fonts change,
-  // and everything using font-main / font-secondary carries over automatically.
-  // This year: main = CossetteTexte (display), secondary = Pix32 (body/UI).
+  // and everything using font-primary / font-secondary carries over automatically.
+  // This year: primary = CossetteTexte (display), secondary = Pix32 (body/UI).
   // figtree is deprecated (last year's font) and being migrated out — see #794.
-  main: "var(--font-cossetteTexte)",
+  primary: "var(--font-cossetteTexte)",
   secondary: "var(--font-pix32)",
 } as const;
 
@@ -93,7 +93,7 @@ export const typography = {
     textTransform: "none" as const,
   },
   p1: {
-    fontFamily: fonts.figtree, //
+    fontFamily: fonts.pix32, //
     fontWeight: "500", // Medium
     fontSize: "24px", //
     lineHeight: "auto",
@@ -101,7 +101,7 @@ export const typography = {
     textTransform: "none" as const,
   },
   p2: {
-    fontFamily: fonts.figtree,
+    fontFamily: fonts.pix32,
     fontWeight: "500",
     fontSize: "16px",
     lineHeight: "auto",
@@ -109,7 +109,7 @@ export const typography = {
     textTransform: "none" as const,
   },
   p3: {
-    fontFamily: fonts.figtree,
+    fontFamily: fonts.pix32,
     fontWeight: "500",
     fontSize: "14px",
     lineHeight: "auto",

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -52,6 +52,10 @@ export const fonts = {
   cossetteTexte: "var(--font-cossetteTexte)",
   figtree: "var(--font-figtree)",
   pix32: "var(--font-pix32)",
+  // Semantic aliases — repoint these two when the yearly theme fonts change,
+  // and everything using font-main / font-secondary carries over automatically.
+  main: "var(--font-cossetteTexte)",
+  secondary: "var(--font-figtree)",
 } as const;
 
 // ------------------------------------------------------------

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -60,7 +60,7 @@ const MyApp: AppType<{ session: Session | null }> = ({
       />
       <SpeedInsights />
       <main
-        className={`${figtree.variable} font-figtree ${cossetteTexte.variable} font-cossetteTexte ${pix32.variable} font-pix32`}
+        className={`${figtree.variable} font-secondary ${cossetteTexte.variable} font-cossetteTexte ${pix32.variable} font-pix32`}
       >
         <TooltipProvider>
           <Component {...pageProps} />

--- a/src/pages/apply.tsx
+++ b/src/pages/apply.tsx
@@ -160,7 +160,7 @@ export default function Apply() {
           {/* Mobile Header */}
           <div className="fixed z-[99] flex h-16 w-full items-center justify-between bg-white px-4 shadow-sm">
             <div className="h-8 w-8"></div>
-            <h1 className="font-figtree text-lg font-semibold text-heavy">
+            <h1 className="font-secondary text-lg font-semibold text-heavy">
               {step
                 ? step.charAt(0).toUpperCase() + step.slice(1)
                 : "Application"}
@@ -183,7 +183,7 @@ export default function Apply() {
               </div>
 
               {step ? (
-                <div className="flex-1 overflow-visible font-figtree">
+                <div className="flex-1 overflow-visible font-secondary">
                   <ApplyForm step={step} />
                 </div>
               ) : (
@@ -249,7 +249,7 @@ export default function Apply() {
                         />
                       </div>
                       <div
-                        className="scrollbar min-h-0 flex-1 overflow-auto rounded-md pb-2 pl-1 pr-4 font-figtree"
+                        className="scrollbar min-h-0 flex-1 overflow-auto rounded-md pb-2 pl-1 pr-4 font-secondary"
                         ref={desktopScrollRef}
                       >
                         <ApplyForm

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -153,17 +153,24 @@ export default Dashboard;
 export const getServerSideProps = async (
   context: GetServerSidePropsContext,
 ) => {
-  // Organizers land here via login's default callbackUrl; send them to the
+  // On prod everything's blocked (disabledRedirect -> /). On dev/preview,
+  // organizers land here via login's default callbackUrl; send them to the
   // application review instead of the (disabled) hacker dashboard.
-  const session = await getServerSession(context.req, context.res, authOptions);
-  if (session) {
-    const user = await db.query.users.findFirst({
-      where: (users, { eq }) => eq(users.id, session.user.id),
-    });
-    if (user?.type === "organizer") {
-      return {
-        redirect: { destination: "/internal/review", permanent: false },
-      };
+  if (process.env.VERCEL_ENV !== "production") {
+    const session = await getServerSession(
+      context.req,
+      context.res,
+      authOptions,
+    );
+    if (session) {
+      const user = await db.query.users.findFirst({
+        where: (users, { eq }) => eq(users.id, session.user.id),
+      });
+      if (user?.type === "organizer") {
+        return {
+          redirect: { destination: "/internal/review", permanent: false },
+        };
+      }
     }
   }
 

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -155,7 +155,7 @@ export const getServerSideProps = async (
 ) => {
   // On prod everything's blocked (disabledRedirect -> /). On dev/preview,
   // organizers land here via login's default callbackUrl; send them to the
-  // application review instead of the (disabled) hacker dashboard.
+  // internal dashboard instead of the (disabled) hacker dashboard.
   if (process.env.VERCEL_ENV !== "production") {
     const session = await getServerSession(
       context.req,
@@ -168,7 +168,7 @@ export const getServerSideProps = async (
       });
       if (user?.type === "organizer") {
         return {
-          redirect: { destination: "/internal/review", permanent: false },
+          redirect: { destination: "/internal/dashboard", permanent: false },
         };
       }
     }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -101,7 +101,7 @@ import { db } from "~/server/db";
 //           {/* Mobile Header */}
 //           <div className="fixed z-[99] flex h-16 w-full items-center justify-between bg-white px-4 shadow-sm">
 //             <div className="h-8 w-8" />
-//             <h1 className="font-figtree text-sm font-semibold text-heavy">
+//             <h1 className="font-secondary text-sm font-semibold text-heavy">
 //               Home
 //             </h1>
 //             <div className="flex h-8 w-8 items-center justify-center">

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -10,9 +10,10 @@
 // import CharacterIcon from "~/components/dashboard/CharacterIcon";
 // import SubmittedDisplay from "~/components/dashboard/SubmittedDisplay";
 import { disabledRedirect } from "~/utils/redirect";
-// import { getServerSession } from "next-auth";
-// import { authOptions } from "~/server/auth";
-// import { db } from "~/server/db";
+import type { GetServerSidePropsContext } from "next";
+import { getServerSession } from "next-auth";
+import { authOptions } from "~/server/auth";
+import { db } from "~/server/db";
 
 // function getApplyStep(stepValue: string | null): ApplyStepFull | null {
 //   return applySteps.find((s) => s.step === stepValue) ?? null;
@@ -149,4 +150,23 @@ import { disabledRedirect } from "~/utils/redirect";
 const Dashboard = () => null;
 export default Dashboard;
 
-export const getServerSideProps = disabledRedirect;
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext,
+) => {
+  // Organizers land here via login's default callbackUrl; send them to the
+  // application review instead of the (disabled) hacker dashboard.
+  const session = await getServerSession(context.req, context.res, authOptions);
+  if (session) {
+    const user = await db.query.users.findFirst({
+      where: (users, { eq }) => eq(users.id, session.user.id),
+    });
+    if (user?.type === "organizer") {
+      return {
+        redirect: { destination: "/internal/review", permanent: false },
+      };
+    }
+  }
+
+  // Everyone else keeps the existing disabled-page behavior.
+  return disabledRedirect();
+};

--- a/src/pages/internal/adjust-status.tsx
+++ b/src/pages/internal/adjust-status.tsx
@@ -146,7 +146,7 @@ export default function AdjustStatus() {
           </p>
 
           <div className="mb-6">
-            <h2 className="mb-2 font-figtree text-medium">
+            <h2 className="mb-2 font-secondary text-medium">
               Upload CSV of Emails
             </h2>
             <Input
@@ -187,7 +187,9 @@ export default function AdjustStatus() {
           </div>
 
           <div className="mb-6">
-            <h2 className="mb-2 font-figtree text-medium">Add Single Email</h2>
+            <h2 className="mb-2 font-secondary text-medium">
+              Add Single Email
+            </h2>
             <div className="flex gap-2">
               <Input
                 type="email"
@@ -209,7 +211,9 @@ export default function AdjustStatus() {
           </div>
 
           <div className="mb-6">
-            <h2 className="mb-2 font-figtree text-medium">Select New Status</h2>
+            <h2 className="mb-2 font-secondary text-medium">
+              Select New Status
+            </h2>
             <Select
               value={status}
               onValueChange={(v) => setStatus(v as Status)}

--- a/src/pages/internal/dashboard.tsx
+++ b/src/pages/internal/dashboard.tsx
@@ -1,141 +1,97 @@
-import type { GetServerSidePropsContext } from "next";
-// import { getServerSession } from "next-auth";
-// import { db } from "~/server/db";
-// import { authOptions } from "~/server/auth";
-// import { api } from "~/utils/api";
-// import { DataTable } from "~/components/ui/data-table";
-// import { reviewDashboardColumns } from "~/components/columns";
-// import { Button } from "~/components/ui/button";
-// import Link from "next/link";
-// import {
-//   Accordion,
-//   AccordionContent,
-//   AccordionItem,
-//   AccordionTrigger,
-// } from "~/components/ui/accordion";
-// import { Input } from "~/components/ui/input";
-// import { useState } from "react";
+import { disabledRedirect } from "~/utils/redirect";
+import { api } from "~/utils/api";
+import { DataTable } from "~/components/ui/data-table";
+import { reviewDashboardColumns } from "~/components/columns";
+import { Button } from "~/components/ui/button";
+import Link from "next/link";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "~/components/ui/accordion";
+import { Input } from "~/components/ui/input";
+import { useState } from "react";
 
-// export async function getServerSideProps(context: GetServerSidePropsContext) {
-//   const session = await getServerSession(context.req, context.res, authOptions);
-//   if (!session) {
-//     return {
-//       redirect: {
-//         destination: "/login",
-//         permanent: false,
-//       },
-//     };
-//   }
-//   const user = await db.query.users.findFirst({
-//     where: (users, { eq }) => eq(users.id, session.user.id),
-//   });
+const Internal = () => {
+  const { data: reviewData } = api.review.getByOrganizer.useQuery();
+  const { data: nextReviewId } = api.review.getNextId.useQuery({});
+  const { data: reviewCount } = api.review.getReviewCounts.useQuery();
+  const [search, setSearch] = useState("");
 
-//   if (user?.type !== "organizer") {
-//     return {
-//       redirect: {
-//         destination: "/dashboard",
-//         permanent: false,
-//       },
-//     };
-//   }
+  const filteredData = reviewData?.filter((review) => {
+    return (
+      review.applicant.email.toLowerCase().includes(search.toLowerCase()) ||
+      review.application.firstName
+        ?.toLowerCase()
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        .includes(search.toLowerCase()) ||
+      review.application.lastName?.toLowerCase().includes(search.toLowerCase())
+    );
+  });
 
-//   return {
-//     props: {},
-//   };
-// }
+  return (
+    <div className="bg-hw-linear-gradient-day flex flex-col items-center justify-center bg-primary-100 py-4">
+      <h1 className="z-10 mb-4 text-3xl">Internal Dashboard</h1>
+      <Accordion type="multiple" className="z-10 mb-3">
+        <AccordionItem key="leaderboard" value="leaderboard">
+          <AccordionTrigger className="text-left">Leaderboard</AccordionTrigger>
+          <AccordionContent className="text-left">
+            <table className="table-auto">
+              <thead>
+                <tr>
+                  <th className="pr-2">Rank</th>
+                  <th>Reviewer</th>
+                  <th>Reviews</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reviewCount?.map((reviewer, index) => (
+                  <tr key={index}>
+                    <td className="text-center">{index + 1}</td>
+                    <td className="text-center">{reviewer.reviewerName}</td>
+                    <td className="text-center">{reviewer.reviewCount}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+      <div className="z-10 mb-3 text-sm">
+        {reviewData?.length} applications reviewed!
+      </div>
+      <div className="z-10 mb-3 flex gap-3">
+        {nextReviewId ? (
+          <Button asChild variant="primary">
+            <Link href={`/internal/review?applicant=${nextReviewId}`}>
+              Review Next
+            </Link>
+          </Button>
+        ) : (
+          <div>All reviews completed! 🎉</div>
+        )}
+        <Button asChild variant="primary">
+          <Link href="/internal/adjust-status">Adjust Status</Link>
+        </Button>
+      </div>
+      <Input
+        className="z-10 mb-4 mt-3 w-96"
+        placeholder="Search by name or email"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      <div className="z-10 font-figtree text-medium">
+        {reviewData && filteredData ? (
+          <DataTable columns={reviewDashboardColumns} data={filteredData} />
+        ) : (
+          <h2>Loading...</h2>
+        )}
+      </div>
+    </div>
+  );
+};
 
-// const Internal = () => {
-//   const { data: reviewData } = api.review.getByOrganizer.useQuery();
-//   const { data: nextReviewId } = api.review.getNextId.useQuery({});
-//   const { data: reviewCount } = api.review.getReviewCounts.useQuery();
-//   const [search, setSearch] = useState("");
-
-//   const filteredData = reviewData?.filter((review) => {
-//     return (
-//       review.applicant.email.toLowerCase().includes(search.toLowerCase()) ||
-//       review.application.firstName
-//         ?.toLowerCase()
-//         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-//         .includes(search.toLowerCase()) ||
-//       review.application.lastName?.toLowerCase().includes(search.toLowerCase())
-//     );
-//   });
-
-//   return (
-//     <div className="bg-hw-linear-gradient-day flex flex-col items-center justify-center bg-primary-100 py-4">
-//       <h1 className="z-10 mb-4 text-3xl">Internal Dashboard</h1>
-//       <Accordion type="multiple" className="z-10 mb-3">
-//         <AccordionItem key="leaderboard" value="leaderboard">
-//           <AccordionTrigger className="text-left">Leaderboard</AccordionTrigger>
-//           <AccordionContent className="text-left">
-//             <table className="table-auto">
-//               <thead>
-//                 <tr>
-//                   <th className="pr-2">Rank</th>
-//                   <th>Reviewer</th>
-//                   <th>Reviews</th>
-//                 </tr>
-//               </thead>
-//               <tbody>
-//                 {reviewCount?.map((reviewer, index) => (
-//                   <tr key={index}>
-//                     <td className="text-center">{index + 1}</td>
-//                     <td className="text-center">{reviewer.reviewerName}</td>
-//                     <td className="text-center">{reviewer.reviewCount}</td>
-//                   </tr>
-//                 ))}
-//               </tbody>
-//             </table>
-//           </AccordionContent>
-//         </AccordionItem>
-//       </Accordion>
-//       <div className="z-10 mb-3 text-sm">
-//         {reviewData?.length} applications reviewed!
-//       </div>
-//       <div className="z-10 mb-3 flex gap-3">
-//         {nextReviewId ? (
-//           <Button asChild variant="primary">
-//             <Link href={`/internal/review?applicant=${nextReviewId}`}>
-//               Review Next
-//             </Link>
-//           </Button>
-//         ) : (
-//           <div>All reviews completed! 🎉</div>
-//         )}
-//         <Button asChild variant="primary">
-//           <Link href="/internal/adjust-status">Adjust Status</Link>
-//         </Button>
-//       </div>
-//       <Input
-//         className="z-10 mb-4 mt-3 w-96"
-//         placeholder="Search by name or email"
-//         value={search}
-//         onChange={(e) => setSearch(e.target.value)}
-//       />
-//       <div className="z-10 font-figtree text-medium">
-//         {reviewData && filteredData ? (
-//           <DataTable columns={reviewDashboardColumns} data={filteredData} />
-//         ) : (
-//           <h2>Loading...</h2>
-//         )}
-//       </div>
-//     </div>
-//   );
-// };
-
-// export default Internal;
-
-// Temporary placeholder component - redirect happens in getServerSideProps
-const Internal = () => null;
 export default Internal;
 
-export const getServerSideProps = async (
-  context: GetServerSidePropsContext,
-) => {
-  return {
-    redirect: {
-      destination: "/internal/review",
-      permanent: false,
-    },
-  };
-};
+export const getServerSideProps = disabledRedirect;

--- a/src/pages/internal/dashboard.tsx
+++ b/src/pages/internal/dashboard.tsx
@@ -81,7 +81,7 @@ const Internal = () => {
         value={search}
         onChange={(e) => setSearch(e.target.value)}
       />
-      <div className="z-10 font-figtree text-medium">
+      <div className="z-10 font-secondary text-medium">
         {reviewData && filteredData ? (
           <DataTable columns={reviewDashboardColumns} data={filteredData} />
         ) : (

--- a/src/pages/internal/dashboard.tsx
+++ b/src/pages/internal/dashboard.tsx
@@ -134,7 +134,7 @@ export const getServerSideProps = async (
 ) => {
   return {
     redirect: {
-      destination: "/scavenger",
+      destination: "/internal/review",
       permanent: false,
     },
   };

--- a/src/pages/internal/review.tsx
+++ b/src/pages/internal/review.tsx
@@ -95,7 +95,7 @@ const Review = () => {
   return (
     <>
       <SEO title="Application Review" noindex />
-      <main className=" font-figtreen flex flex-col items-center bg-primary-50 font-figtree">
+      <main className=" font-secondaryn flex flex-col items-center bg-primary-50 font-secondary">
         <div className="relative z-[100] w-full items-center md:flex">
           <div
             id="left-panel"
@@ -367,7 +367,7 @@ const Review = () => {
           >
             <div className="z-10 my-8 flex h-[90vh] flex-col items-center justify-center overflow-auto overflow-auto rounded-xl border border-primary-300 bg-primary-100 pl-8 text-sm md:my-auto md:max-w-[800px]">
               {applicationData ? (
-                <div className="custom-scroll z-50 flex h-[90vh] flex-col overflow-auto rounded-[10px] rounded-lg px-2 py-4 font-figtree">
+                <div className="custom-scroll z-50 flex h-[90vh] flex-col overflow-auto rounded-[10px] rounded-lg px-2 py-4 font-secondary">
                   <Tooltip>
                     <TooltipTrigger>
                       <div className="mt-4 text-base">{`${applicationData?.firstName} ${applicationData?.lastName}`}</div>

--- a/src/pages/internal/review.tsx
+++ b/src/pages/internal/review.tsx
@@ -4,7 +4,7 @@ import { Button } from "~/components/ui/button";
 import { Slider } from "~/components/ui/slider";
 import { api } from "~/utils/api";
 import Link from "next/link";
-import { authRedirectOrganizer } from "~/utils/redirect";
+import { disabledRedirect } from "~/utils/redirect";
 import type { z } from "zod";
 import { reviewSaveSchema } from "~/schemas/review";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -557,4 +557,4 @@ const postfix = (num: number) => {
 };
 
 export default Review;
-export const getServerSideProps = authRedirectOrganizer;
+export const getServerSideProps = disabledRedirect;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -56,7 +56,7 @@ export default function Login() {
             Sign into your account
           </h2>
           <form onSubmit={handleSubmit}>
-            <h2 className="mb-1 font-figtree text-medium">Email</h2>
+            <h2 className="mb-1 font-secondary text-medium">Email</h2>
             <Input
               id="email"
               name="email"
@@ -68,7 +68,7 @@ export default function Login() {
               onChange={(e) => setEmail(e.target.value)}
               required
             />
-            <h2 className="mb-1 font-figtree text-medium">Password</h2>
+            <h2 className="mb-1 font-secondary text-medium">Password</h2>
             <Input
               id="password"
               name="password"
@@ -101,7 +101,7 @@ export default function Login() {
             <GithubAuthButton redirect={callbackUrl} />
             <DiscordAuthButton redirect={callbackUrl} />
           </div>
-          <div className="mt-6 font-figtree text-medium">
+          <div className="mt-6 font-secondary text-medium">
             Don&apos;t have an account yet?
             <Button
               asChild
@@ -116,7 +116,7 @@ export default function Login() {
               </Link>
             </Button>
           </div>
-          <div className="font-figtree text-medium">
+          <div className="font-secondary text-medium">
             Forget password?
             <Button
               asChild

--- a/src/pages/logout.tsx
+++ b/src/pages/logout.tsx
@@ -19,7 +19,7 @@ const Logout = () => {
       .catch((e) => console.error(e));
   };
   return (
-    <div className="font-figtree font-semibold text-heavy">
+    <div className="font-secondary font-semibold text-heavy">
       Hi there{name ? `, ${name}` : ""}! |{" "}
       <button className="hover:underline" onClick={() => logout()}>
         Sign Out

--- a/src/pages/not-verified.tsx
+++ b/src/pages/not-verified.tsx
@@ -46,7 +46,7 @@ const NotVerified = () => {
       <SEO title="Verify Email" noindex />
 
       <div className="bg-hw-radial-gradient flex h-screen flex-col items-center justify-center">
-        <div className="z-10 flex w-full max-w-2xl flex-col justify-center gap-6 rounded-lg bg-violet-50 bg-white p-8 font-figtree shadow-md">
+        <div className="z-10 flex w-full max-w-2xl flex-col justify-center gap-6 rounded-lg bg-violet-50 bg-white p-8 font-secondary shadow-md">
           <p className="text-lg">
             You have registered successfully! Please verify your email before
             continuing. If you do not see an email, try requesting a new one.

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -60,7 +60,7 @@ export default function Register() {
             Create your account
           </h2>
           <form onSubmit={handleSubmit}>
-            <h2 className="mb-2 font-figtree text-medium">Email</h2>
+            <h2 className="mb-2 font-secondary text-medium">Email</h2>
             <Input
               required
               id="email"
@@ -72,7 +72,7 @@ export default function Register() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
             />
-            <h2 className="mb-2 font-figtree text-medium">Password</h2>
+            <h2 className="mb-2 font-secondary text-medium">Password</h2>
             <Input
               required
               id="password"
@@ -105,7 +105,7 @@ export default function Register() {
             <GithubAuthButton redirect="/dashboard" register={true} />
             <DiscordAuthButton redirect="/dashboard" register={true} />
           </div>
-          <div className="mt-6 font-figtree text-medium">
+          <div className="mt-6 font-secondary text-medium">
             Already have an account?
             <Button
               asChild
@@ -120,7 +120,7 @@ export default function Register() {
               </Link>
             </Button>
           </div>
-          <div className="font-figtree text-medium">
+          <div className="font-secondary text-medium">
             Forget password?
             <Button
               asChild

--- a/src/pages/scan/[activity].tsx
+++ b/src/pages/scan/[activity].tsx
@@ -654,7 +654,7 @@ const ScanActivityPage = () => {
           onClick={() => {
             void router.push("/scavenger");
           }}
-          className="font-figtree text-heavy transition-colors hover:text-emphasis"
+          className="font-secondary text-heavy transition-colors hover:text-emphasis"
         >
           Back
         </button>
@@ -663,24 +663,26 @@ const ScanActivityPage = () => {
             {activityName}
           </h1>
           {itemLoading && (
-            <p className="font-figtree text-sm text-medium">
+            <p className="font-secondary text-sm text-medium">
               Loading item details...
             </p>
           )}
           {itemData && (
             <div className="space-y-1">
               {itemData.description && (
-                <p className="font-figtree text-sm text-medium">
+                <p className="font-secondary text-sm text-medium">
                   {itemData.description}
                 </p>
               )}
-              <p className="font-figtree text-sm font-medium text-heavy">
+              <p className="font-secondary text-sm font-medium text-heavy">
                 Points: {itemData.points}
               </p>
             </div>
           )}
           {!itemLoading && !itemData && (itemId ?? itemCode) && (
-            <p className="font-figtree text-sm text-red-600">Item not found</p>
+            <p className="font-secondary text-sm text-red-600">
+              Item not found
+            </p>
           )}
         </div>
       </header>
@@ -707,12 +709,12 @@ const ScanActivityPage = () => {
         {/* Camera Error / Start Camera Button */}
         {!cameraActive && cameraError && (
           <div className="absolute inset-0 flex flex-col items-center justify-center bg-gray-300 p-6">
-            <p className="mb-4 text-center font-figtree text-heavy">
+            <p className="mb-4 text-center font-secondary text-heavy">
               {cameraError}
             </p>
             <button
               onClick={startCamera}
-              className="rounded-lg bg-white px-6 py-3 font-figtree font-medium text-heavy shadow-md transition-colors hover:bg-violet-100 active:bg-violet-200"
+              className="rounded-lg bg-white px-6 py-3 font-secondary font-medium text-heavy shadow-md transition-colors hover:bg-violet-100 active:bg-violet-200"
             >
               Start Camera
             </button>
@@ -723,10 +725,10 @@ const ScanActivityPage = () => {
         {/* {testMode && (
           <div className="absolute inset-0 flex flex-col items-center justify-center p-6 space-y-6">
             <div className="text-center space-y-2">
-              <p className="font-figtree text-lg text-heavy font-medium">
+              <p className="font-secondary text-lg text-heavy font-medium">
                 Test Mode - No Camera Required
               </p>
-              <p className="font-figtree text-sm text-medium">
+              <p className="font-secondary text-sm text-medium">
                 Enter a user ID or QR code data to simulate scanning
               </p>
             </div>
@@ -737,7 +739,7 @@ const ScanActivityPage = () => {
                 value={testUserId}
                 onChange={(e) => setTestUserId(e.target.value)}
                 placeholder="Enter user ID (e.g., user123 or a QR code)"
-                className="w-full px-4 py-3 rounded-lg border-2 border-white bg-white font-figtree text-heavy placeholder:text-medium focus:outline-none focus:ring-2 focus:ring-violet-500"
+                className="w-full px-4 py-3 rounded-lg border-2 border-white bg-white font-secondary text-heavy placeholder:text-medium focus:outline-none focus:ring-2 focus:ring-violet-500"
                 onKeyDown={(e) => {
                   if (e.key === "Enter" && testUserId.trim()) {
                     handleQRCodeDetected(testUserId.trim());
@@ -751,7 +753,7 @@ const ScanActivityPage = () => {
                   }
                 }}
                 disabled={!testUserId.trim() || status !== "scanning"}
-                className="w-full px-4 py-3 rounded-lg bg-white hover:bg-violet-100 active:bg-violet-200 font-figtree font-medium text-heavy shadow-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full px-4 py-3 rounded-lg bg-white hover:bg-violet-100 active:bg-violet-200 font-secondary font-medium text-heavy shadow-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Simulate Scan
               </button>
@@ -781,7 +783,7 @@ const ScanActivityPage = () => {
                     startCamera();
                   }
                 }}
-                className="w-full px-4 py-2 rounded-lg bg-violet-200 hover:bg-violet-300 font-figtree font-medium text-heavy transition-colors text-sm"
+                className="w-full px-4 py-2 rounded-lg bg-violet-200 hover:bg-violet-300 font-secondary font-medium text-heavy transition-colors text-sm"
               >
                 Try Camera Again
               </button>
@@ -792,14 +794,14 @@ const ScanActivityPage = () => {
 
       {/* Success Overlay */}
       {status === "success" && scannedName && (
-        <div className="absolute bottom-8 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-white px-4 py-3 font-figtree text-heavy opacity-100 shadow-lg transition-opacity duration-300">
+        <div className="absolute bottom-8 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-white px-4 py-3 font-secondary text-heavy opacity-100 shadow-lg transition-opacity duration-300">
           {scannedName} scanned successfully
         </div>
       )}
 
       {/* Error Overlay - only show for non-"already scanned" errors */}
       {status === "error" && errorMessage && (
-        <div className="absolute bottom-8 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-red-100 px-4 py-3 font-figtree text-red-700 opacity-100 shadow-lg transition-opacity duration-300">
+        <div className="absolute bottom-8 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-red-100 px-4 py-3 font-secondary text-red-700 opacity-100 shadow-lg transition-opacity duration-300">
           {errorMessage}
         </div>
       )}

--- a/src/pages/scan/already-scanned.tsx
+++ b/src/pages/scan/already-scanned.tsx
@@ -66,8 +66,8 @@ export default function AlreadyScannedPage() {
         {/* Activity Name */}
         {activityName && (
           <div className="space-y-1">
-            <p className="font-figtree text-sm text-medium">Activity:</p>
-            <p className="font-figtree text-lg font-medium text-heavy">
+            <p className="font-secondary text-sm text-medium">Activity:</p>
+            <p className="font-secondary text-lg font-medium text-heavy">
               {activityName}
             </p>
           </div>
@@ -76,14 +76,14 @@ export default function AlreadyScannedPage() {
         {/* User Name */}
         {userName && (
           <div className="space-y-1">
-            <p className="font-figtree text-sm text-medium">User:</p>
-            <p className="font-figtree text-lg font-medium text-heavy">
+            <p className="font-secondary text-sm text-medium">User:</p>
+            <p className="font-secondary text-lg font-medium text-heavy">
               {userName}
             </p>
           </div>
         )}
 
-        <p className="font-figtree text-medium">
+        <p className="font-secondary text-medium">
           This item has already been scanned by this user.
         </p>
 
@@ -91,13 +91,13 @@ export default function AlreadyScannedPage() {
         <div className="space-y-3">
           <button
             onClick={handleBackToScanning}
-            className="w-full rounded-lg bg-primary px-6 py-3 font-figtree font-medium text-primary-foreground transition-colors hover:bg-primary-700"
+            className="w-full rounded-lg bg-primary px-6 py-3 font-secondary font-medium text-primary-foreground transition-colors hover:bg-primary-700"
           >
             Back to Scanning
           </button>
           <button
             onClick={handleBackToActivities}
-            className="mx-auto font-figtree text-sm text-medium underline-offset-4 transition-colors hover:text-heavy hover:underline"
+            className="mx-auto font-secondary text-sm text-medium underline-offset-4 transition-colors hover:text-heavy hover:underline"
           >
             Back to Activities
           </button>

--- a/src/pages/scan/success.tsx
+++ b/src/pages/scan/success.tsx
@@ -66,8 +66,8 @@ export default function ScanSuccessPage() {
         {/* Activity Name */}
         {activityName && (
           <div className="space-y-1">
-            <p className="font-figtree text-sm text-medium">Activity:</p>
-            <p className="font-figtree text-lg font-medium text-heavy">
+            <p className="font-secondary text-sm text-medium">Activity:</p>
+            <p className="font-secondary text-lg font-medium text-heavy">
               {activityName}
             </p>
           </div>
@@ -76,8 +76,8 @@ export default function ScanSuccessPage() {
         {/* User Name */}
         {userName && (
           <div className="space-y-1">
-            <p className="font-figtree text-sm text-medium">User:</p>
-            <p className="font-figtree text-lg font-medium text-heavy">
+            <p className="font-secondary text-sm text-medium">User:</p>
+            <p className="font-secondary text-lg font-medium text-heavy">
               {userName}
             </p>
           </div>
@@ -88,14 +88,14 @@ export default function ScanSuccessPage() {
           {activityParam && (
             <button
               onClick={handleBackToScanning}
-              className="w-full rounded-lg bg-primary px-6 py-3 font-figtree font-medium text-primary-foreground transition-colors hover:bg-primary-700"
+              className="w-full rounded-lg bg-primary px-6 py-3 font-secondary font-medium text-primary-foreground transition-colors hover:bg-primary-700"
             >
               Back to Scanning
             </button>
           )}
           <button
             onClick={handleBackToActivities}
-            className="mx-auto font-figtree text-sm text-medium underline-offset-4 transition-colors hover:text-heavy hover:underline"
+            className="mx-auto font-secondary text-sm text-medium underline-offset-4 transition-colors hover:text-heavy hover:underline"
           >
             Back to Activities
           </button>

--- a/src/pages/scans.tsx
+++ b/src/pages/scans.tsx
@@ -49,7 +49,7 @@ const ScansPage = () => {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search by name, activity, scanner"
-            className="w-full rounded-lg border-2 border-white bg-[#f5f2f6] px-4 py-2 pl-10 font-figtree text-heavy placeholder:text-medium focus:outline-none focus:ring-2 focus:ring-violet-500"
+            className="w-full rounded-lg border-2 border-white bg-[#f5f2f6] px-4 py-2 pl-10 font-secondary text-heavy placeholder:text-medium focus:outline-none focus:ring-2 focus:ring-violet-500"
           />
           <svg
             className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-medium"
@@ -70,7 +70,7 @@ const ScansPage = () => {
         <div className="grid w-full grid-cols-2 gap-2 md:grid-cols-4 md:gap-4">
           <button
             onClick={() => setFilter("all")}
-            className={`rounded-lg bg-white px-4 py-2 font-figtree text-heavy transition-colors hover:bg-violet-100 ${
+            className={`rounded-lg bg-white px-4 py-2 font-secondary text-heavy transition-colors hover:bg-violet-100 ${
               filter === "all" ? "font-bold" : "font-medium"
             }`}
           >
@@ -78,7 +78,7 @@ const ScansPage = () => {
           </button>
           <button
             onClick={() => setFilter("meals")}
-            className={`rounded-lg bg-white px-4 py-2 font-figtree text-heavy transition-colors hover:bg-violet-100 ${
+            className={`rounded-lg bg-white px-4 py-2 font-secondary text-heavy transition-colors hover:bg-violet-100 ${
               filter === "meals" ? "font-bold" : "font-medium"
             }`}
           >
@@ -86,7 +86,7 @@ const ScansPage = () => {
           </button>
           <button
             onClick={() => setFilter("workshops")}
-            className={`rounded-lg bg-white px-4 py-2 font-figtree text-heavy transition-colors hover:bg-violet-100 ${
+            className={`rounded-lg bg-white px-4 py-2 font-secondary text-heavy transition-colors hover:bg-violet-100 ${
               filter === "workshops" ? "font-bold" : "font-medium"
             }`}
           >
@@ -94,7 +94,7 @@ const ScansPage = () => {
           </button>
           <button
             onClick={() => setFilter("activities")}
-            className={`rounded-lg bg-white px-4 py-2 font-figtree text-heavy transition-colors hover:bg-violet-100 ${
+            className={`rounded-lg bg-white px-4 py-2 font-secondary text-heavy transition-colors hover:bg-violet-100 ${
               filter === "activities" ? "font-bold" : "font-medium"
             }`}
           >
@@ -102,7 +102,7 @@ const ScansPage = () => {
           </button>
           <button
             onClick={() => setFilter("attendance")}
-            className={`rounded-lg bg-white px-3 py-2 font-figtree text-heavy transition-colors hover:bg-violet-100 md:px-4 ${
+            className={`rounded-lg bg-white px-3 py-2 font-secondary text-heavy transition-colors hover:bg-violet-100 md:px-4 ${
               filter === "attendance" ? "font-bold" : "font-medium"
             }`}
           >
@@ -114,7 +114,7 @@ const ScansPage = () => {
           </button>
           <button
             onClick={() => setFilter("wins")}
-            className={`rounded-lg bg-white px-3 py-2 font-figtree text-heavy transition-colors hover:bg-violet-100 md:px-4 ${
+            className={`rounded-lg bg-white px-3 py-2 font-secondary text-heavy transition-colors hover:bg-violet-100 md:px-4 ${
               filter === "wins" ? "font-bold" : "font-medium"
             }`}
           >
@@ -123,7 +123,7 @@ const ScansPage = () => {
           </button>
           <button
             onClick={() => setFilter("bonus")}
-            className={`rounded-lg bg-white px-4 py-2 font-figtree text-heavy transition-colors hover:bg-violet-100 ${
+            className={`rounded-lg bg-white px-4 py-2 font-secondary text-heavy transition-colors hover:bg-violet-100 ${
               filter === "bonus" ? "font-bold" : "font-medium"
             }`}
           >

--- a/src/pages/scavenger.tsx
+++ b/src/pages/scavenger.tsx
@@ -1,38 +1,6 @@
 import Scan from "~/components/scan";
-import type { GetServerSidePropsContext } from "next";
-import { getServerSession } from "next-auth";
-import { authOptions } from "~/server/auth";
-import { db } from "~/server/db";
+import { disabledRedirect } from "~/utils/redirect";
 
 export default Scan;
 
-export const getServerSideProps = async (
-  context: GetServerSidePropsContext,
-) => {
-  const session = await getServerSession(context.req, context.res, authOptions);
-  if (!session) {
-    return {
-      redirect: {
-        destination: "/login",
-        permanent: false,
-      },
-    };
-  }
-
-  const user = await db.query.users.findFirst({
-    where: (users, { eq }) => eq(users.id, session.user.id),
-  });
-
-  if (user?.type !== "organizer") {
-    return {
-      redirect: {
-        destination: "/live",
-        permanent: false,
-      },
-    };
-  }
-
-  return {
-    props: {},
-  };
-};
+export const getServerSideProps = disabledRedirect;

--- a/src/pages/scavenger/redeem.tsx
+++ b/src/pages/scavenger/redeem.tsx
@@ -78,7 +78,7 @@ const RedeemPage = () => {
           onClick={() => {
             void router.push("/scavenger");
           }}
-          className="font-figtree text-heavy transition-colors hover:text-emphasis"
+          className="font-secondary text-heavy transition-colors hover:text-emphasis"
         >
           Back
         </button>
@@ -91,13 +91,13 @@ const RedeemPage = () => {
         </h1>
 
         {isLoading && (
-          <div className="text-center font-figtree text-medium">
+          <div className="text-center font-secondary text-medium">
             Loading prizes...
           </div>
         )}
 
         {!isLoading && (!rewards || rewards.length === 0) && (
-          <div className="text-center font-figtree text-medium">
+          <div className="text-center font-secondary text-medium">
             No prizes available
           </div>
         )}
@@ -108,7 +108,7 @@ const RedeemPage = () => {
               <button
                 key={reward.id}
                 onClick={() => handleRewardClick(reward.id)}
-                className="flex w-full items-center justify-between rounded-lg bg-white px-4 py-3 text-left font-figtree shadow-md transition-colors hover:bg-violet-100 active:bg-violet-200"
+                className="flex w-full items-center justify-between rounded-lg bg-white px-4 py-3 text-left font-secondary shadow-md transition-colors hover:bg-violet-100 active:bg-violet-200"
               >
                 <div className="flex-1">
                   <div className="font-semibold text-heavy">

--- a/src/pages/scavenger/redeem/[rewardId].tsx
+++ b/src/pages/scavenger/redeem/[rewardId].tsx
@@ -492,7 +492,7 @@ const RedeemScanPage = () => {
           onClick={() => {
             void router.push("/scavenger/redeem");
           }}
-          className="font-figtree text-heavy transition-colors hover:text-emphasis"
+          className="font-secondary text-heavy transition-colors hover:text-emphasis"
         >
           Back
         </button>
@@ -501,27 +501,27 @@ const RedeemScanPage = () => {
             {rewardName}
           </h1>
           {rewardLoading && (
-            <p className="font-figtree text-sm text-medium">
+            <p className="font-secondary text-sm text-medium">
               Loading reward details...
             </p>
           )}
           {rewardData && (
             <div className="space-y-1">
               {rewardData.description && (
-                <p className="font-figtree text-sm text-medium">
+                <p className="font-secondary text-sm text-medium">
                   {formatTitle(rewardData.description)}
                 </p>
               )}
-              <p className="font-figtree text-sm font-medium text-heavy">
+              <p className="font-secondary text-sm font-medium text-heavy">
                 Cost: {rewardData.costPoints} points
               </p>
-              <p className="font-figtree text-sm text-medium">
+              <p className="font-secondary text-sm text-medium">
                 Quantity left: {rewardData.quantity ?? "∞"}
               </p>
             </div>
           )}
           {!rewardLoading && !rewardData && rewardId && (
-            <p className="font-figtree text-sm text-red-600">
+            <p className="font-secondary text-sm text-red-600">
               Reward not found
             </p>
           )}
@@ -548,12 +548,12 @@ const RedeemScanPage = () => {
         {/* Camera Error / Start Camera Button */}
         {!cameraActive && cameraError && (
           <div className="absolute inset-0 flex flex-col items-center justify-center bg-gray-300 p-6">
-            <p className="mb-4 text-center font-figtree text-heavy">
+            <p className="mb-4 text-center font-secondary text-heavy">
               {cameraError}
             </p>
             <button
               onClick={startCamera}
-              className="rounded-lg bg-white px-6 py-3 font-figtree font-medium text-heavy shadow-md transition-colors hover:bg-violet-100 active:bg-violet-200"
+              className="rounded-lg bg-white px-6 py-3 font-secondary font-medium text-heavy shadow-md transition-colors hover:bg-violet-100 active:bg-violet-200"
             >
               Start Camera
             </button>
@@ -563,14 +563,14 @@ const RedeemScanPage = () => {
 
       {/* Success Overlay */}
       {status === "success" && scannedName && (
-        <div className="absolute bottom-8 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-white px-4 py-3 font-figtree text-heavy opacity-100 shadow-lg transition-opacity duration-300">
+        <div className="absolute bottom-8 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-white px-4 py-3 font-secondary text-heavy opacity-100 shadow-lg transition-opacity duration-300">
           {scannedName} redeemed successfully
         </div>
       )}
 
       {/* Error Overlay */}
       {status === "error" && errorMessage && (
-        <div className="absolute bottom-8 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-red-100 px-4 py-3 font-figtree text-red-700 opacity-100 shadow-lg transition-opacity duration-300">
+        <div className="absolute bottom-8 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-red-100 px-4 py-3 font-secondary text-red-700 opacity-100 shadow-lg transition-opacity duration-300">
           {errorMessage}
         </div>
       )}

--- a/src/pages/scavenger/redeem/error.tsx
+++ b/src/pages/scavenger/redeem/error.tsx
@@ -80,8 +80,8 @@ export default function RedeemErrorPage() {
         {/* Reward Name */}
         {rewardName && (
           <div className="space-y-1">
-            <p className="font-figtree text-sm text-medium">Reward:</p>
-            <p className="font-figtree text-lg font-medium text-heavy">
+            <p className="font-secondary text-sm text-medium">Reward:</p>
+            <p className="font-secondary text-lg font-medium text-heavy">
               {formatTitle(rewardName)}
             </p>
           </div>
@@ -90,8 +90,8 @@ export default function RedeemErrorPage() {
         {/* User Name */}
         {userName && (
           <div className="space-y-1">
-            <p className="font-figtree text-sm text-medium">User:</p>
-            <p className="font-figtree text-lg font-medium text-heavy">
+            <p className="font-secondary text-sm text-medium">User:</p>
+            <p className="font-secondary text-lg font-medium text-heavy">
               {userName}
             </p>
           </div>
@@ -99,8 +99,8 @@ export default function RedeemErrorPage() {
 
         {/* Error Details */}
         <div className="space-y-1">
-          <p className="font-figtree text-sm text-medium">Error:</p>
-          <p className="font-figtree text-sm text-red-600">
+          <p className="font-secondary text-sm text-medium">Error:</p>
+          <p className="font-secondary text-sm text-red-600">
             {getErrorMessage()}
           </p>
         </div>
@@ -108,7 +108,7 @@ export default function RedeemErrorPage() {
         {/* Back Button */}
         <button
           onClick={handleBackToRewards}
-          className="w-full rounded-lg bg-primary px-6 py-3 font-figtree font-medium text-primary-foreground transition-colors hover:bg-primary-700"
+          className="w-full rounded-lg bg-primary px-6 py-3 font-secondary font-medium text-primary-foreground transition-colors hover:bg-primary-700"
         >
           Back to Rewards
         </button>

--- a/src/pages/scavenger/redeem/success.tsx
+++ b/src/pages/scavenger/redeem/success.tsx
@@ -60,8 +60,8 @@ export default function RedeemSuccessPage() {
         {/* Reward Name */}
         {rewardName && (
           <div className="space-y-1">
-            <p className="font-figtree text-sm text-medium">Reward:</p>
-            <p className="font-figtree text-lg font-medium text-heavy">
+            <p className="font-secondary text-sm text-medium">Reward:</p>
+            <p className="font-secondary text-lg font-medium text-heavy">
               {formatTitle(rewardName)}
             </p>
           </div>
@@ -70,8 +70,8 @@ export default function RedeemSuccessPage() {
         {/* User Name */}
         {userName && (
           <div className="space-y-1">
-            <p className="font-figtree text-sm text-medium">Redeemed by:</p>
-            <p className="font-figtree text-lg font-medium text-heavy">
+            <p className="font-secondary text-sm text-medium">Redeemed by:</p>
+            <p className="font-secondary text-lg font-medium text-heavy">
               {userName}
             </p>
           </div>
@@ -80,7 +80,7 @@ export default function RedeemSuccessPage() {
         {/* Back Button */}
         <button
           onClick={handleBackToRewards}
-          className="w-full rounded-lg bg-primary px-6 py-3 font-figtree font-medium text-primary-foreground transition-colors hover:bg-primary-700"
+          className="w-full rounded-lg bg-primary px-6 py-3 font-secondary font-medium text-primary-foreground transition-colors hover:bg-primary-700"
         >
           Back to Rewards
         </button>

--- a/src/pages/verify.tsx
+++ b/src/pages/verify.tsx
@@ -98,7 +98,7 @@ const Verify = () => {
           )}
           {verifyFailed && (
             <div className="flex flex-col justify-center">
-              <div className="mb-6 text-left font-figtree">
+              <div className="mb-6 text-left font-secondary">
                 Invalid or Expired Verification Token.
               </div>
               {verifyToken && (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -156,13 +156,13 @@ html {
     @apply font-cossetteTexte text-sm-display font-bold leading-default tracking-default text-heavy;
   }
   .p1 {
-    @apply font-figtree text-lg-p font-medium leading-normal tracking-default text-black;
+    @apply font-secondary text-lg-p font-medium leading-normal tracking-default text-black;
   }
   .p2 {
-    @apply font-figtree text-md-p font-medium leading-normal tracking-default text-black;
+    @apply font-secondary text-md-p font-medium leading-normal tracking-default text-black;
   }
   .p3 {
-    @apply font-figtree text-sm-p font-medium leading-normal tracking-default text-black;
+    @apply font-secondary text-sm-p font-medium leading-normal tracking-default text-black;
   }
   .subtitle-lg {
     @apply font-cossetteTexte text-lg-sub font-normal uppercase leading-normal tracking-subtitle text-black;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -146,6 +146,8 @@ const config = {
         "button-icon": tokens.shadows.icon,
       },
       fontFamily: {
+        main: [tokens.fonts.main],
+        secondary: [tokens.fonts.secondary],
         figtree: ["var(--font-figtree)"],
         cossetteTexte: [tokens.fonts.cossetteTexte],
         pix32: [tokens.fonts.pix32],
@@ -202,7 +204,7 @@ const config = {
       cursor: {
         "pixel-default": "url('/cursors/cursor-default.webp'),auto",
         "pixel-hover": "url('/cursors/hover-hand.webp'),pointer",
-        "telescope":"url('/cursors/telescope.webp'),pointer",
+        telescope: "url('/cursors/telescope.webp'),pointer",
       },
       keyframes: {
         "bounce-jump": {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -146,7 +146,7 @@ const config = {
         "button-icon": tokens.shadows.icon,
       },
       fontFamily: {
-        main: [tokens.fonts.main],
+        primary: [tokens.fonts.primary],
         secondary: [tokens.fonts.secondary],
         figtree: ["var(--font-figtree)"],
         cossetteTexte: [tokens.fonts.cossetteTexte],


### PR DESCRIPTION
Consolidated PR (absorbed the old #792). Three areas:

## 1. Font system
- Semantic aliases **`font-primary`** (CossetteTexte, display) + **`font-secondary`** (Pix32, body/UI) in `tokens.ts` — repoint two lines to swap fonts yearly.
- **Deprecated figtree**: replaced all `font-figtree` class usages (**170 across 41 files**) + `globals.css` `.p1/.p2/.p3` + typography tokens with `font-secondary` (= pix32).
- Figtree loader/var remain as now-unused plumbing (follow-up removal).

## 2. Scavenger scan page
- Tokenized: SecondaryButton, `bg-highlight`, blue hover tokens, and `font-primary`/`font-secondary`.

## 3. Internal routing + dashboard
- **Revived** the `/internal/dashboard` hub (Leaderboard, Review Next, Adjust Status, applicant DataTable).
- Organizer login → `/internal/dashboard` on dev (prod-gated); fixes the review page's 'Back to Dashboard' loop.
- `/internal/*` + `/scavenger` → `disabledRedirect`: **open on dev, blocked on prod**.

# Checklist
- [x] tsc + prettier clean, full test suite passes (169)
- [ ] Eyeball preview: scavenger fonts (pix32 body), organizer lands on dashboard, internal routes render on preview / blocked on prod