### PR TITLE
Remove 1s artificial delay on preregistration submit

### DIFF
--- a/src/server/api/routers/preregistration.ts
+++ b/src/server/api/routers/preregistration.ts
@@ -14,7 +14,6 @@ export const preregistrationRouter = createTRPCRouter({
     .input(preregistrationCreateSchema)
     .mutation(async ({ input }) => {
       try {
-        const startTime = Date.now();
         const existingPreregistration =
           await db.query.preregistrations.findFirst({
             where: ({ email }, { eq }) => eq(email, input.email),
@@ -31,11 +30,6 @@ export const preregistrationRouter = createTRPCRouter({
           .insert(preregistrations)
           .values(input)
           .returning();
-
-        // 1 second artifical delay
-        const remainingTime = 1000 - (Date.now() - startTime);
-        if (remainingTime > 0)
-          await new Promise((res) => setTimeout(res, remainingTime));
 
         return createdPreregistration[0];
       } catch (error) {


### PR DESCRIPTION
The preregistration create mutation padded every response to a 1-second minimum via a `setTimeout`, causing a noticeable lag between submitting the update-signup email and the submit button responding. Removed the artificial delay and the now-unused `startTime`. `tsc` clean.

Wants this on both `dev` and `main` — merge here, then promote `dev`→`main`.