### PR TITLE
Promote dev → main: remove preregistration submit delay

### DIFF
--- a/src/server/api/routers/preregistration.ts
+++ b/src/server/api/routers/preregistration.ts
@@ -14,7 +14,6 @@ export const preregistrationRouter = createTRPCRouter({
     .input(preregistrationCreateSchema)
     .mutation(async ({ input }) => {
       try {
-        const startTime = Date.now();
         const existingPreregistration =
           await db.query.preregistrations.findFirst({
             where: ({ email }, { eq }) => eq(email, input.email),
@@ -31,11 +30,6 @@ export const preregistrationRouter = createTRPCRouter({
           .insert(preregistrations)
           .values(input)
           .returning();
-
-        // 1 second artifical delay
-        const remainingTime = 1000 - (Date.now() - startTime);
-        if (remainingTime > 0)
-          await new Promise((res) => setTimeout(res, remainingTime));
 
         return createdPreregistration[0];
       } catch (error) {


### PR DESCRIPTION
Promotes the single outstanding dev commit: removal of the 1s artificial delay on preregistration submit (#802). `tsc` clean.

Merge with a **merge commit** (not squash) to keep dev/main aligned.