### PR TITLE
Campaign sends from isolated mail.hackwestern.com subdomain

### DIFF
--- a/scripts/send-campaign.ts
+++ b/scripts/send-campaign.ts
@@ -60,6 +60,7 @@ export function renderFor(sub: Sub) {
     headers: {
       "List-Unsubscribe": `<${postUrl}>`,
       "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      "Reply-To": "hello@hackwestern.com",
     } as Record<string, string>,
   };
 }
@@ -110,7 +111,10 @@ async function main() {
   for (const r of rows) {
     const { subject, html, headers } = renderFor(r);
     const res = await sendEmail({
-      from: "Hack Western Team <hello@hackwestern.com>",
+      // Bulk campaign sends from an isolated subdomain so a spam/bounce hit
+      // can't poison transactional (password-reset/verify) deliverability on
+      // the root domain. Replies still route to the monitored inbox (Reply-To).
+      from: "Hack Western <updates@mail.hackwestern.com>",
       to: r.email, subject, html, headers,
     });
     const outcome = classifyResult(res);


### PR DESCRIPTION
Bulk hacker campaign now sends from `updates@mail.hackwestern.com` instead of the root `hello@hackwestern.com`, so campaign spam/bounce reputation can't poison transactional (password-reset/verify) deliverability. `Reply-To: hello@hackwestern.com` keeps replies flowing to the monitored inbox.

**Requires** onboarding `mail.hackwestern.com` to Cloudflare Email Sending (dashboard, 1-click DNS) before the campaign runs — else sends 10203 (sending disabled). `tsc` clean, tests pass.