### PR TITLE
Canonical hackwestern.com base for email unsubscribe links

### DIFF
--- a/scripts/send-campaign.ts
+++ b/scripts/send-campaign.ts
@@ -4,9 +4,10 @@ import { emailSubscribers } from "~/server/db/schema";
 import { sendEmail } from "~/server/mail";
 import { campaignTemplate } from "~/server/api/routers/email-templates";
 import { editionFromSource } from "~/server/subscribers";
-import { env } from "~/env";
 
-const BASE = env.NEXTAUTH_URL?.replace(/\/$/, "") ?? "https://www.hackwestern.com";
+// Email links must be canonical + permanent — never a per-deployment preview
+// URL — so hardcode the public domain rather than the deployment's env.
+const BASE = "https://www.hackwestern.com";
 const SUBJECT = "Hack Western 13 is coming!";
 const DELAY_MS = 500;
 

--- a/src/server/api/routers/preregistration.ts
+++ b/src/server/api/routers/preregistration.ts
@@ -6,10 +6,11 @@ import { db } from "~/server/db";
 import { sendEmail } from "~/server/mail";
 import { normalizeEmail, generateUnsubscribeToken } from "~/server/subscribers";
 import { signupTemplate } from "./email-templates";
-import { env } from "~/env";
 
-const BASE =
-  env.NEXTAUTH_URL?.replace(/\/$/, "") ?? "https://www.hackwestern.com";
+// Email links must be canonical + permanent — never a per-deployment preview
+// URL (which may be scheme-less or expire) — so hardcode the public domain
+// rather than trusting the deployment's NEXTAUTH_URL.
+const BASE = "https://www.hackwestern.com";
 
 const preregistrationCreateSchema = createInsertSchema(preregistrations).omit({
   createdAt: true,


### PR DESCRIPTION
Unsubscribe links were built from each deployment's `NEXTAUTH_URL`. On a preview deploy that's a scheme-less `…vercel.app` hostname → the link won't open, and its token lives in the preview DB, not prod. Hardcode `https://hackwestern.com` for email links (signup + campaign) so they're always canonical + permanent. `tsc` clean, tests pass.