### PR TITLE
Hacker campaign drip workflow (+ --only scoped test)

### DIFF
--- a/.github/workflows/send-campaign.yml
+++ b/.github/workflows/send-campaign.yml
@@ -1,0 +1,91 @@
+name: Hacker Email Campaign Drip
+
+# Sends the HW11/12 → HW13 campaign in small hourly batches so volume stays
+# low and reputation-safe. Idempotent + resumable via email_subscriber.last_sent_at.
+#
+# SAFETY / ARMING:
+#   - Scheduled runs DRY-RUN until the repo variable CAMPAIGN_LIVE == 'true'.
+#     Arm it when ready:  gh variable set CAMPAIGN_LIVE --body true
+#     Pause anytime:      gh variable set CAMPAIGN_LIVE --body false
+#   - Manual run: Actions → this workflow → Run workflow → tick "send".
+#   - Scoped test: Run workflow → tick "send" + set "only" to one email to send
+#     the whole pipeline to just that address (ignores the last-sent gate).
+#
+# SELF-TERMINATION:
+#   - When a send run finds 0 eligible recipients (list drained), it disables
+#     this workflow (gh workflow disable) so the cron stops firing.
+
+on:
+  schedule:
+    - cron: "0 13-23 * * *" # hourly, ~9am–7pm ET (13:00–23:00 UTC)
+  workflow_dispatch:
+    inputs:
+      send:
+        description: "Actually send (unticked = dry run)"
+        type: boolean
+        default: false
+      only:
+        description: "Scope to a single email (test). Blank = normal batch."
+        type: string
+        default: ""
+
+concurrency:
+  group: email-campaign-drip
+  cancel-in-progress: false
+
+permissions:
+  actions: write # needed to self-disable when the list is drained
+
+jobs:
+  drip:
+    runs-on: ubuntu-latest
+    environment: Production
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      CLOUDFLARE_EMAIL_API_TOKEN: ${{ secrets.CLOUDFLARE_EMAIL_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      SKIP_ENV_VALIDATION: "1"
+      CHUNK: "40" # ~40/run × ~11 runs/day ≈ 440/day → ~9–10 days for 4,070
+      START: "2026-07-30T00:00:00Z" # campaign kickoff; gates re-sends (must precede first send)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci
+
+      - name: Decide send vs dry-run
+        id: mode
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_SEND: ${{ inputs.send }}
+          VAR_LIVE: ${{ vars.CAMPAIGN_LIVE }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ]; then ARMED="$INPUT_SEND"; else ARMED="$VAR_LIVE"; fi
+          if [ "$ARMED" = "true" ]; then echo "flag=--send" >> "$GITHUB_OUTPUT"; else echo "flag=" >> "$GITHUB_OUTPUT"; fi
+          echo "Send mode: ${ARMED:-false}"
+
+      - name: Run drip batch
+        env:
+          FLAG: ${{ steps.mode.outputs.flag }}
+          ONLY: ${{ inputs.only }}
+        run: |
+          set -o pipefail
+          args=(--chunk="$CHUNK" --start="$START")
+          [ -n "$FLAG" ] && args+=("$FLAG")
+          [ -n "$ONLY" ] && args+=(--only="$ONLY")
+          npx tsx scripts/send-campaign.ts "${args[@]}" | tee out.log
+
+      - name: Self-disable when list is drained
+        if: ${{ steps.mode.outputs.flag == '--send' && inputs.only == '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WF_NAME: ${{ github.workflow }}
+        run: |
+          if grep -q "Chunk: 0 recipient(s)" out.log; then
+            echo "✅ Campaign complete — 0 recipients left. Disabling this workflow."
+            gh workflow disable "$WF_NAME"
+          else
+            echo "Recipients remain — will run again next tick."
+          fi

--- a/scripts/send-campaign.ts
+++ b/scripts/send-campaign.ts
@@ -19,6 +19,7 @@ export async function selectEligible(
   chunkSize: number,
   campaignStart: Date,
   source?: string,
+  only?: string,
 ): Promise<SubRow[]> {
   return (await db
     .select({
@@ -32,12 +33,17 @@ export async function selectEligible(
       and(
         isNull(emailSubscribers.unsubscribedAt),
         isNull(emailSubscribers.bouncedAt),
-        or(
-          isNull(emailSubscribers.lastSentAt),
-          lt(emailSubscribers.lastSentAt, campaignStart),
-        ),
-        // Optional cohort filter; omit to send to both hw11 + hw12.
-        source ? eq(emailSubscribers.source, source) : undefined,
+        // --only: target one address (test mode) — ignores the last-sent gate
+        // so it's re-runnable. Otherwise: normal single-send eligibility + cohort.
+        only
+          ? eq(emailSubscribers.email, only)
+          : and(
+              or(
+                isNull(emailSubscribers.lastSentAt),
+                lt(emailSubscribers.lastSentAt, campaignStart),
+              ),
+              source ? eq(emailSubscribers.source, source) : undefined,
+            ),
       ),
     )
     .orderBy(asc(emailSubscribers.id))
@@ -100,11 +106,17 @@ async function main() {
     console.error(`Invalid --source "${source}" — use hw11 or hw12 (or omit for both).`);
     process.exit(1);
   }
+  const only = process.argv.find((a) => a.startsWith("--only="))?.split("=")[1];
 
-  const rows = await selectEligible(chunk, campaignStart, source);
+  const rows = await selectEligible(chunk, campaignStart, source, only);
 
+  const scope = only
+    ? ` [only=${only}]`
+    : source
+      ? ` [source=${source}]`
+      : " [all sources]";
   console.log(
-    `Chunk: ${rows.length} recipient(s)${source ? ` [source=${source}]` : " [all sources]"}. Mode: ${SEND ? "SEND" : "DRY RUN"}.`,
+    `Chunk: ${rows.length} recipient(s)${scope}. Mode: ${SEND ? "SEND" : "DRY RUN"}.`,
   );
   if (!SEND) { rows.forEach((r, i) => console.log(`${i + 1}. ${r.email}`)); return; }
 


### PR DESCRIPTION
Hourly self-terminating GitHub Actions drip for the HW11/12 campaign (dry-run until `CAMPAIGN_LIVE=true`, self-disables when the list drains). Free (public repo).

Adds `--only=<email>` to `send-campaign.ts` + a workflow `only` input so the **whole action can be tested against a single address** (e.g. your own inbox) before arming — ignores the last-sent gate so it's re-runnable, and skips self-disable in only-mode.

Runs in `Production` env for prod `DATABASE_URL` + `CLOUDFLARE_*`. `tsc` clean, tests pass.