### PR TITLE
Fix campaign send: reply-to via CF reply_to field

### DIFF
--- a/scripts/send-campaign.ts
+++ b/scripts/send-campaign.ts
@@ -67,7 +67,6 @@ export function renderFor(sub: Sub) {
     headers: {
       "List-Unsubscribe": `<${postUrl}>`,
       "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-      "Reply-To": "hello@hackwestern.com",
     } as Record<string, string>,
   };
 }
@@ -126,8 +125,9 @@ async function main() {
     const res = await sendEmail({
       // Bulk campaign sends from an isolated subdomain so a spam/bounce hit
       // can't poison transactional (password-reset/verify) deliverability on
-      // the root domain. Replies still route to the monitored inbox (Reply-To).
+      // the root domain. Replies still route to the monitored inbox (reply_to).
       from: "Hack Western <updates@mail.hackwestern.com>",
+      replyTo: "hello@hackwestern.com",
       to: r.email, subject, html, headers,
     });
     const outcome = classifyResult(res);

--- a/src/server/mail.ts
+++ b/src/server/mail.ts
@@ -6,6 +6,7 @@ export interface SendEmailOptions {
   html: string;
   text?: string;
   from?: string;
+  replyTo?: string;
   headers?: Record<string, string>;
 }
 
@@ -67,6 +68,8 @@ export const sendEmail = async (
           subject: options.subject,
           html: options.html,
           text: options.text ?? options.html.replace(/<[^>]*>?/gm, ""),
+          // Cloudflare's `reply_to` is a first-class field, NOT a custom header.
+          ...(options.replyTo ? { reply_to: options.replyTo } : {}),
           ...(options.headers ? { headers: options.headers } : {}),
         }),
       },


### PR DESCRIPTION
Scoped test caught it: CF rejects `Reply-To` as a custom header (allowlist — it's a first-class field) → `10202 email.invalid`. Pass it via `reply_to` instead. tsc + tests pass.