### PR TITLE
Add privacy policy page + SES transactional re-appeal handoff

### DIFF
--- a/SES-HANDOFF.md
+++ b/SES-HANDOFF.md
@@ -1,0 +1,99 @@
+# SES / Email Deliverability — Handoff
+
+> Working doc for continuing the SES production-access effort. **Delete before merging to `main`** (it's a handoff note, not shipping code). No secrets in here — account IDs and case numbers only.
+
+## TL;DR
+Marketing SES production access was **rejected** (new-account + `MARKETING` mail-type = highest bar). Plan: **re-appeal as TRANSACTIONAL first** to get out of the sandbox and build reputation; keep marketing OFF SES for now. Account-trust + SES Part A setup is **done**. Remaining: add Website URL on the AWS account, (optionally) deploy the new privacy page, then **reply to the AWS case** with the transactional-first draft below.
+
+## Key decisions
+- **Re-appeal as transactional, not marketing.** Transactional is the lower approval bar; `hackwestern.com` mail (verification / RSVP / application confirmations) genuinely is transactional.
+- **Marketing stays off SES for now.** The ~4,000-person "you're auto-subscribed" blast is a cold-list marketing send — do NOT send it via SES (sandbox or a future grant) right now. It's parked.
+- **Brevo was considered and dropped** (user's call). No managed-provider work in flight.
+- Reply to the **existing case**, don't open a new one (unless it's been resolved >14 days and won't reopen → then new case referencing the old ID).
+
+## Status — DONE
+- ✅ AWS root email already on org domain (`hello@hackwestern.com`) — no change needed.
+- ✅ Expired payment method (Meghan Lo card) **replaced** with a valid one.
+- ✅ `hackwestern.com` verified as an SES identity in **us-east-1**, DKIM **SUCCESS**.
+- ✅ Account-level **suppression** enabled (BOUNCE + COMPLAINT) — account-wide (also covers `marketing.hackwestern.com`).
+- ✅ Clean **mailbox-simulator** sends (success/bounce/complaint).
+- ✅ SES account state: `ProductionAccessEnabled=false` (still sandbox), `SendingEnabled=true`, `EnforcementStatus=HEALTHY`, quota 200/day @ 1/s.
+- ✅ Privacy policy page built + pushed to this branch (`/privacy`).
+
+## Status — REMAINING (before sending the re-appeal)
+1. **AWS Account page → add Website URL** = `https://hackwestern.com` (currently None). Also Company name = `Hack Western`. Quick trust signal.
+2. **Confirm privacy page content** (see below) — provider list + résumé→sponsor sharing.
+3. **Run `next lint` + prettier** on the two changed files (couldn't run in the cloud container — no deps installed).
+4. **Deploy the privacy page** so `hackwestern.com/privacy` is live — required only if you want the draft to claim a privacy policy (see draft note). Otherwise use the softened line.
+5. **Reply to AWS case #178547265200428** with the draft below.
+
+## This branch's code changes (commit `ea1e6b8`)
+- **`src/pages/privacy.tsx`** (new) — full privacy policy at `/privacy`. Tailored to the real stack: Vercel Speed Insights (only analytics), GitHub/Google/Discord OAuth sign-in, Vercel/Neon/Cloudflare/AWS/Zoho providers, sponsor résumé sharing. Uses `SEO` component, `cossetteTexte`/`figtree` fonts, indexable.
+- **`src/pages/index.tsx`** — "Privacy Policy" link under the sign-up form (matches the existing "Interested in sponsoring?" link).
+- **Verify before merge:** provider list accurate? résumé→sponsor sharing OK to state as implied consent? Run lint/prettier.
+- **Aside:** existing sponsor link points to `hello@hackwestern.me` (`.me`, not `.com`) — possible typo routing sponsor inquiries nowhere. Not touched here.
+
+To view: `git checkout claude/ses-limits-rejected-u08bz5 && npm run dev` → http://localhost:3000/privacy (static, no DB/login needed).
+
+## Re-appeal draft (paste as a reply to case #178547265200428)
+> Plain text. Every claim below is now true given the setup above. **Privacy line:** as written it says "shows our public sign-up form, and includes our contact information" (safe now). Only change it to "…and includes our privacy policy" once `hackwestern.com/privacy` is actually deployed.
+
+```
+Hello,
+
+Thank you for the review. We would like to be reconsidered, and we have
+revised our request to a narrower, lower-risk scope rather than
+resubmitting the same one.
+
+Revised request: production access for TRANSACTIONAL email only, from our
+verified domain hackwestern.com, in us-east-1. We are not requesting bulk
+or promotional sending in this request. We are asking for a modest initial
+sending quota matching our real volume (on the order of a few hundred
+emails per day).
+
+About us: Hack Western is a registered student-run non-profit hackathon at
+Western University in London, Ontario, Canada. Our website,
+https://hackwestern.com, describes the event, shows our public sign-up
+form, and includes our contact information.
+
+What we send (all transactional, triggered by a user action):
+- Account email-verification and password-reset messages.
+- Confirmation emails when someone submits an application or RSVPs.
+- A confirmation email when someone signs up on our website to receive
+  updates, sent only in response to their own signup.
+These are one-to-one, transaction-triggered messages to the individual who
+took the action. We are not sending unsolicited mail to a list under this
+request.
+
+Recipient and reputation handling:
+- We have enabled SES account-level suppression for bounces and complaints,
+  and we monitor the bounce and complaint reputation metrics in the SES
+  console, pausing if either approaches AWS thresholds.
+- We have tested our setup against the SES mailbox simulator (success,
+  bounce, and complaint) to confirm our bounce and complaint handling
+  behaves correctly before any production volume.
+- Every recipient reached this way took an explicit action (verification,
+  application, RSVP, or opt-in signup) immediately before the email is sent.
+
+Authentication and account:
+- hackwestern.com is a verified SES identity with DKIM signing enabled and
+  passing, and SPF and DMARC are published for the domain.
+- Our AWS root-account contact is an address on our own hackwestern.com
+  domain, and our account billing is current and verified.
+
+Prior context: our organization previously used a different provider on
+shared sending infrastructure. We have since moved to properly
+authenticated, dedicated identities under our own domain, which is why we
+are establishing this SES setup cleanly from the start.
+
+We are happy to provide any additional detail. Thank you for reconsidering.
+
+Best regards,
+Hack Western Organizing Team
+```
+
+## Reference
+- AWS account: **279138051063** (Amazon Web Services Canada, Inc.), region **us-east-1**.
+- Support case: **#178547265200428** (SES production access).
+- SES identities: `hackwestern.com` (transactional, this effort) + `marketing.hackwestern.com` (marketing, custom MAIL FROM `bounce.marketing.hackwestern.com`, DMARC p=quarantine).
+- Re-appeal facts (verified against AWS docs + re:Post + practitioners): denials are NOT final; reply to the same case; no cooldown; change something material; a case resolved >14 days can't be reopened → file a new one referencing the old ID.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import Image from "next/image";
-import Link from "next/link";
 import React from "react";
 import { PreregistrationForm } from "~/components/preregistration-form";
 
@@ -194,12 +193,6 @@ export default function Home() {
           >
             Interested in sponsoring?
           </a>
-          <Link
-            href="/privacy"
-            className="cursor-pixel-hover text-[16px] font-medium text-[#2E547A]"
-          >
-            Privacy Policy
-          </Link>
         </div>
       </div>
     </main>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import React from "react";
 import { PreregistrationForm } from "~/components/preregistration-form";
 
@@ -193,6 +194,12 @@ export default function Home() {
           >
             Interested in sponsoring?
           </a>
+          <Link
+            href="/privacy"
+            className="cursor-pixel-hover text-[16px] font-medium text-[#2E547A]"
+          >
+            Privacy Policy
+          </Link>
         </div>
       </div>
     </main>

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -7,7 +7,9 @@ function H2({ children }: { children: ReactNode }) {
 }
 
 function H3({ children }: { children: ReactNode }) {
-  return <h3 className="mt-6 text-base font-semibold text-heavy">{children}</h3>;
+  return (
+    <h3 className="mt-6 text-base font-semibold text-heavy">{children}</h3>
+  );
 }
 
 function P({ children }: { children: ReactNode }) {
@@ -51,31 +53,31 @@ export default function Privacy() {
             <p className="font-semibold text-heavy">Key points</p>
             <ul className="mt-2 list-disc space-y-1 pl-5 text-heavy">
               <li>
-                We collect the personal information you share with us to run Hack
-                Western, and some anonymized data to improve our services.
+                We collect the personal information you share with us to run
+                Hack Western, and some anonymized data to improve our services.
               </li>
               <li>
                 We don&apos;t sell your data, and we don&apos;t track you for
                 advertising (there are no ads on our site).
               </li>
               <li>
-                If you submit a r&eacute;sum&eacute;, we may share it with sponsors
-                for recruiting purposes.
+                If you submit a r&eacute;sum&eacute;, we may share it with
+                sponsors for recruiting purposes.
               </li>
               <li>
-                You can request that we provide, update, or delete your data at any
-                time by emailing <Mail />.
+                You can request that we provide, update, or delete your data at
+                any time by emailing <Mail />.
               </li>
             </ul>
           </section>
 
           <H2>Preface</H2>
           <P>
-            At Hack Western, we care about privacy and personal data as much as you
-            do. We are a not-for-profit, student-run hackathon at Western University
-            in London, Ontario, Canada, and we respect your rights as a user. This
-            policy explains what we collect, how we use it, who we share it with, and
-            the rights you have over it.
+            At Hack Western, we care about privacy and personal data as much as
+            you do. We are a not-for-profit, student-run hackathon at Western
+            University in London, Ontario, Canada, and we respect your rights as
+            a user. This policy explains what we collect, how we use it, who we
+            share it with, and the rights you have over it.
           </P>
 
           <H2>Terminology</H2>
@@ -85,15 +87,16 @@ export default function Privacy() {
               team.
             </li>
             <li>
-              <strong>The Event</strong> &mdash; the annual Hack Western hackathon.
+              <strong>The Event</strong> &mdash; the annual Hack Western
+              hackathon.
             </li>
             <li>
-              <strong>Participant</strong> &mdash; applicants, hackers, volunteers,
-              mentors, sponsors, and other attendees.
+              <strong>Participant</strong> &mdash; applicants, hackers,
+              volunteers, mentors, sponsors, and other attendees.
             </li>
             <li>
-              <strong>Providers</strong> &mdash; third parties that help us host the
-              event and operate our services.
+              <strong>Providers</strong> &mdash; third parties that help us host
+              the event and operate our services.
             </li>
             <li>
               <strong>Partners</strong> &mdash; sponsors and other third parties
@@ -103,149 +106,152 @@ export default function Privacy() {
 
           <H2>Data we collect</H2>
           <P>
-            We collect data in three broad situations: when you visit our website,
-            when you apply or sign up, and at the event.
+            We collect data in three broad situations: when you visit our
+            website, when you apply or sign up, and at the event.
           </P>
 
           <H3>When you visit our website</H3>
           <P>
-            We use cookies to keep you authenticated across our services. We also
-            collect anonymized performance data through Vercel Speed Insights to
-            understand things like page-load times and improve our site. Our hosting
-            and database providers (Vercel and Neon) process standard technical data
-            needed to serve the site. We do not use advertising or cross-site
-            tracking, and there are no ads on our site.
+            We use cookies to keep you authenticated across our services. We
+            also collect anonymized performance data through Vercel Speed
+            Insights to understand things like page-load times and improve our
+            site. Our hosting and database providers (Vercel and Neon) process
+            standard technical data needed to serve the site. We do not use
+            advertising or cross-site tracking, and there are no ads on our
+            site.
           </P>
 
           <H3>When you apply or sign up</H3>
           <P>
-            <strong>Primary data</strong> &mdash; information we need to run the event
-            and communicate with you, which you provide explicitly through our forms.
-            This includes, but is not limited to, your name, email address, school,
-            application responses, links you share, and any r&eacute;sum&eacute; you
-            submit.
+            <strong>Primary data</strong> &mdash; information we need to run the
+            event and communicate with you, which you provide explicitly through
+            our forms. This includes, but is not limited to, your name, email
+            address, school, application responses, links you share, and any
+            r&eacute;sum&eacute; you submit.
           </P>
           <P>
-            <strong>Optional data</strong> &mdash; some fields are optional and used
-            only to better understand our participants and improve the event. Optional
-            fields are clearly marked and never affect decisions such as your
-            application outcome.
+            <strong>Optional data</strong> &mdash; some fields are optional and
+            used only to better understand our participants and improve the
+            event. Optional fields are clearly marked and never affect decisions
+            such as your application outcome.
           </P>
           <P>
-            <strong>Third-party sign-in data</strong> &mdash; if you choose to sign in
-            with GitHub, Google, or Discord, we receive your name, email address, and
-            authentication credentials for that account, used solely to identify you
-            and provide sign-in access to our services. We will not take any action on
-            your behalf. You can review or unlink this access from your account
-            settings with that provider.
+            <strong>Third-party sign-in data</strong> &mdash; if you choose to
+            sign in with GitHub, Google, or Discord, we receive your name, email
+            address, and authentication credentials for that account, used
+            solely to identify you and provide sign-in access to our services.
+            We will not take any action on your behalf. You can review or unlink
+            this access from your account settings with that provider.
           </P>
 
           <H3>At the event</H3>
           <P>
-            We collect operational data during the event &mdash; for example, QR-code
-            and check-in scans &mdash; to manage logistics such as food quotas and to
-            understand participation in activities.
+            We collect operational data during the event &mdash; for example,
+            QR-code and check-in scans &mdash; to manage logistics such as food
+            quotas and to understand participation in activities.
           </P>
 
           <H2>How we use your data</H2>
           <P>
-            To operate the event, review applications, communicate with you about your
-            application and the event, run event-day logistics, improve our services,
-            and &mdash; where you have opted in &mdash; send you updates you signed up
-            for.
+            To operate the event, review applications, communicate with you
+            about your application and the event, run event-day logistics,
+            improve our services, and &mdash; where you have opted in &mdash;
+            send you updates you signed up for.
           </P>
 
           <H2>Data we share</H2>
 
           <H3>Operational providers</H3>
           <P>
-            To run Hack Western, we use third-party providers to host our website,
-            database, email, and file storage &mdash; currently Vercel, Neon,
-            Cloudflare, Amazon Web Services, and Zoho. These providers process
-            participant data only as needed to provide their services to us. Our
-            providers may change over time as our needs evolve; a current list of
-            major providers can be requested at <Mail />.
+            To run Hack Western, we use third-party providers to host our
+            website, database, email, and file storage &mdash; currently Vercel,
+            Neon, Cloudflare, Amazon Web Services, and Zoho. These providers
+            process participant data only as needed to provide their services to
+            us. Our providers may change over time as our needs evolve; a
+            current list of major providers can be requested at <Mail />.
           </P>
 
           <H3>Sponsor and participant-directed sharing</H3>
           <P>
             We may share personal information with sponsors or partners when you
-            provide it for a partner-related purpose, or when you take part in an
-            activity where sharing is clearly expected. For example: if you submit a
-            r&eacute;sum&eacute;, we may share it with sponsors for recruiting
-            purposes; and if you scan into a sponsor activity, we may share relevant
-            participation information with that sponsor. We aim to make clear, in plain
-            language, when information is being collected for sponsor or partner use.
+            provide it for a partner-related purpose, or when you take part in
+            an activity where sharing is clearly expected. For example: if you
+            submit a r&eacute;sum&eacute;, we may share it with sponsors for
+            recruiting purposes; and if you scan into a sponsor activity, we may
+            share relevant participation information with that sponsor. We aim
+            to make clear, in plain language, when information is being
+            collected for sponsor or partner use.
           </P>
 
           <H3>Anonymous, de-identified, and aggregate data</H3>
           <P>
-            We may share anonymized or aggregate data &mdash; such as the number of
-            applicants or which activities were popular &mdash; publicly or with
-            partners, for purposes like event reporting, transparency, and improving
-            future events. We remove direct identifiers such as names and email
-            addresses from this data.
+            We may share anonymized or aggregate data &mdash; such as the number
+            of applicants or which activities were popular &mdash; publicly or
+            with partners, for purposes like event reporting, transparency, and
+            improving future events. We remove direct identifiers such as names
+            and email addresses from this data.
           </P>
 
           <H3>Legal compliance</H3>
           <P>
-            We may disclose your information to law enforcement or authorities if
-            required by law. We do not sell your personal information.
+            We may disclose your information to law enforcement or authorities
+            if required by law. We do not sell your personal information.
           </P>
 
           <H2>Data security</H2>
           <P>
-            We take data security seriously and use industry-standard measures such as
-            TLS/SSL encryption in transit and hashed credentials at rest. Our data is
-            hosted by reputable providers in the United States and Canada that meet
-            recognized security and compliance standards. If a breach creates a real
-            risk of significant harm, we will notify affected individuals and
-            regulators as soon as feasible after discovery.
+            We take data security seriously and use industry-standard measures
+            such as TLS/SSL encryption in transit and hashed credentials at
+            rest. Our data is hosted by reputable providers in the United States
+            and Canada that meet recognized security and compliance standards.
+            If a breach creates a real risk of significant harm, we will notify
+            affected individuals and regulators as soon as feasible after
+            discovery.
           </P>
 
           <H2>Data retention</H2>
           <P>
-            We retain personal information for as long as reasonably needed to operate
-            Hack Western, support current and future events, and meet legal or
-            operational requirements, unless you request deletion earlier. Deleted
-            data may remain in backups for a short additional period before being
-            purged.
+            We retain personal information for as long as reasonably needed to
+            operate Hack Western, support current and future events, and meet
+            legal or operational requirements, unless you request deletion
+            earlier. Deleted data may remain in backups for a short additional
+            period before being purged.
           </P>
 
           <H2>Your rights</H2>
 
           <H3>Data ownership</H3>
           <P>
-            You own your data. With proof of identity, you may email <Mail /> at any
-            time to request that we provide, update, or delete the personal data we
-            hold about you. We will comply within 30 days, barring legal requirements
-            or exceptional circumstances.
+            You own your data. With proof of identity, you may email <Mail /> at
+            any time to request that we provide, update, or delete the personal
+            data we hold about you. We will comply within 30 days, barring legal
+            requirements or exceptional circumstances.
           </P>
 
           <H3>Data freedom</H3>
           <P>You have several ways to limit what you share with us:</P>
           <ul className="mt-3 list-disc space-y-1 pl-6 text-heavy">
             <li>
-              <strong>Leave optional fields blank.</strong> You may skip any optional
-              field in our forms. Fields marked as required are necessary for our
-              operations; if you object to providing them, you may stop participating
-              and request deletion of your data.
+              <strong>Leave optional fields blank.</strong> You may skip any
+              optional field in our forms. Fields marked as required are
+              necessary for our operations; if you object to providing them, you
+              may stop participating and request deletion of your data.
             </li>
             <li>
-              <strong>Opt out of update emails.</strong> You can stop receiving our
-              news and update emails at any time via the &ldquo;unsubscribe&rdquo; link
-              at the bottom of any such email.
+              <strong>Opt out of update emails.</strong> You can stop receiving
+              our news and update emails at any time via the
+              &ldquo;unsubscribe&rdquo; link at the bottom of any such email.
             </li>
             <li>
-              <strong>Block analytics.</strong> You may use a browser extension to
-              block anonymized analytics if you prefer.
+              <strong>Block analytics.</strong> You may use a browser extension
+              to block anonymized analytics if you prefer.
             </li>
           </ul>
 
           <H2>Questions</H2>
           <P>
-            We welcome feedback on our privacy practices. If you have any questions,
-            concerns, or complaints, contact us at <Mail />.
+            We welcome feedback on our privacy practices. If you have any
+            questions, concerns, or complaints, contact us at <Mail />.
           </P>
         </div>
       </div>

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,0 +1,254 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import SEO from "~/components/seo";
+
+function H2({ children }: { children: ReactNode }) {
+  return <h2 className="mt-10 text-xl font-bold text-heavy">{children}</h2>;
+}
+
+function H3({ children }: { children: ReactNode }) {
+  return <h3 className="mt-6 text-base font-semibold text-heavy">{children}</h3>;
+}
+
+function P({ children }: { children: ReactNode }) {
+  return <p className="mt-3 leading-relaxed text-heavy">{children}</p>;
+}
+
+function Mail() {
+  return (
+    <a
+      className="text-[#7C3AED] hover:underline"
+      href="mailto:hello@hackwestern.com"
+    >
+      hello@hackwestern.com
+    </a>
+  );
+}
+
+export default function Privacy() {
+  return (
+    <>
+      <SEO
+        title="Privacy Policy"
+        description="How Hack Western collects, uses, shares, and protects your personal data."
+      />
+
+      <div className="min-h-screen bg-[#f7f6fb]">
+        <div className="mx-auto max-w-3xl px-6 py-16 font-figtree text-heavy">
+          <Link
+            href="/"
+            className="text-sm font-medium text-[#2E547A] hover:underline"
+          >
+            &larr; Back to hackwestern.com
+          </Link>
+
+          <h1 className="mt-6 font-cossetteTexte text-4xl font-bold text-[#2E547A]">
+            Privacy and Data Policy
+          </h1>
+          <p className="mt-2 text-sm text-medium">Last updated: August 2026</p>
+
+          <section className="mt-8 rounded-lg border border-black/5 bg-white p-5">
+            <p className="font-semibold text-heavy">Key points</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-heavy">
+              <li>
+                We collect the personal information you share with us to run Hack
+                Western, and some anonymized data to improve our services.
+              </li>
+              <li>
+                We don&apos;t sell your data, and we don&apos;t track you for
+                advertising (there are no ads on our site).
+              </li>
+              <li>
+                If you submit a r&eacute;sum&eacute;, we may share it with sponsors
+                for recruiting purposes.
+              </li>
+              <li>
+                You can request that we provide, update, or delete your data at any
+                time by emailing <Mail />.
+              </li>
+            </ul>
+          </section>
+
+          <H2>Preface</H2>
+          <P>
+            At Hack Western, we care about privacy and personal data as much as you
+            do. We are a not-for-profit, student-run hackathon at Western University
+            in London, Ontario, Canada, and we respect your rights as a user. This
+            policy explains what we collect, how we use it, who we share it with, and
+            the rights you have over it.
+          </P>
+
+          <H2>Terminology</H2>
+          <ul className="mt-3 list-disc space-y-1 pl-6 text-heavy">
+            <li>
+              <strong>Us / We / Our</strong> &mdash; the Hack Western organizing
+              team.
+            </li>
+            <li>
+              <strong>The Event</strong> &mdash; the annual Hack Western hackathon.
+            </li>
+            <li>
+              <strong>Participant</strong> &mdash; applicants, hackers, volunteers,
+              mentors, sponsors, and other attendees.
+            </li>
+            <li>
+              <strong>Providers</strong> &mdash; third parties that help us host the
+              event and operate our services.
+            </li>
+            <li>
+              <strong>Partners</strong> &mdash; sponsors and other third parties
+              affiliated with the event.
+            </li>
+          </ul>
+
+          <H2>Data we collect</H2>
+          <P>
+            We collect data in three broad situations: when you visit our website,
+            when you apply or sign up, and at the event.
+          </P>
+
+          <H3>When you visit our website</H3>
+          <P>
+            We use cookies to keep you authenticated across our services. We also
+            collect anonymized performance data through Vercel Speed Insights to
+            understand things like page-load times and improve our site. Our hosting
+            and database providers (Vercel and Neon) process standard technical data
+            needed to serve the site. We do not use advertising or cross-site
+            tracking, and there are no ads on our site.
+          </P>
+
+          <H3>When you apply or sign up</H3>
+          <P>
+            <strong>Primary data</strong> &mdash; information we need to run the event
+            and communicate with you, which you provide explicitly through our forms.
+            This includes, but is not limited to, your name, email address, school,
+            application responses, links you share, and any r&eacute;sum&eacute; you
+            submit.
+          </P>
+          <P>
+            <strong>Optional data</strong> &mdash; some fields are optional and used
+            only to better understand our participants and improve the event. Optional
+            fields are clearly marked and never affect decisions such as your
+            application outcome.
+          </P>
+          <P>
+            <strong>Third-party sign-in data</strong> &mdash; if you choose to sign in
+            with GitHub, Google, or Discord, we receive your name, email address, and
+            authentication credentials for that account, used solely to identify you
+            and provide sign-in access to our services. We will not take any action on
+            your behalf. You can review or unlink this access from your account
+            settings with that provider.
+          </P>
+
+          <H3>At the event</H3>
+          <P>
+            We collect operational data during the event &mdash; for example, QR-code
+            and check-in scans &mdash; to manage logistics such as food quotas and to
+            understand participation in activities.
+          </P>
+
+          <H2>How we use your data</H2>
+          <P>
+            To operate the event, review applications, communicate with you about your
+            application and the event, run event-day logistics, improve our services,
+            and &mdash; where you have opted in &mdash; send you updates you signed up
+            for.
+          </P>
+
+          <H2>Data we share</H2>
+
+          <H3>Operational providers</H3>
+          <P>
+            To run Hack Western, we use third-party providers to host our website,
+            database, email, and file storage &mdash; currently Vercel, Neon,
+            Cloudflare, Amazon Web Services, and Zoho. These providers process
+            participant data only as needed to provide their services to us. Our
+            providers may change over time as our needs evolve; a current list of
+            major providers can be requested at <Mail />.
+          </P>
+
+          <H3>Sponsor and participant-directed sharing</H3>
+          <P>
+            We may share personal information with sponsors or partners when you
+            provide it for a partner-related purpose, or when you take part in an
+            activity where sharing is clearly expected. For example: if you submit a
+            r&eacute;sum&eacute;, we may share it with sponsors for recruiting
+            purposes; and if you scan into a sponsor activity, we may share relevant
+            participation information with that sponsor. We aim to make clear, in plain
+            language, when information is being collected for sponsor or partner use.
+          </P>
+
+          <H3>Anonymous, de-identified, and aggregate data</H3>
+          <P>
+            We may share anonymized or aggregate data &mdash; such as the number of
+            applicants or which activities were popular &mdash; publicly or with
+            partners, for purposes like event reporting, transparency, and improving
+            future events. We remove direct identifiers such as names and email
+            addresses from this data.
+          </P>
+
+          <H3>Legal compliance</H3>
+          <P>
+            We may disclose your information to law enforcement or authorities if
+            required by law. We do not sell your personal information.
+          </P>
+
+          <H2>Data security</H2>
+          <P>
+            We take data security seriously and use industry-standard measures such as
+            TLS/SSL encryption in transit and hashed credentials at rest. Our data is
+            hosted by reputable providers in the United States and Canada that meet
+            recognized security and compliance standards. If a breach creates a real
+            risk of significant harm, we will notify affected individuals and
+            regulators as soon as feasible after discovery.
+          </P>
+
+          <H2>Data retention</H2>
+          <P>
+            We retain personal information for as long as reasonably needed to operate
+            Hack Western, support current and future events, and meet legal or
+            operational requirements, unless you request deletion earlier. Deleted
+            data may remain in backups for a short additional period before being
+            purged.
+          </P>
+
+          <H2>Your rights</H2>
+
+          <H3>Data ownership</H3>
+          <P>
+            You own your data. With proof of identity, you may email <Mail /> at any
+            time to request that we provide, update, or delete the personal data we
+            hold about you. We will comply within 30 days, barring legal requirements
+            or exceptional circumstances.
+          </P>
+
+          <H3>Data freedom</H3>
+          <P>You have several ways to limit what you share with us:</P>
+          <ul className="mt-3 list-disc space-y-1 pl-6 text-heavy">
+            <li>
+              <strong>Leave optional fields blank.</strong> You may skip any optional
+              field in our forms. Fields marked as required are necessary for our
+              operations; if you object to providing them, you may stop participating
+              and request deletion of your data.
+            </li>
+            <li>
+              <strong>Opt out of update emails.</strong> You can stop receiving our
+              news and update emails at any time via the &ldquo;unsubscribe&rdquo; link
+              at the bottom of any such email.
+            </li>
+            <li>
+              <strong>Block analytics.</strong> You may use a browser extension to
+              block anonymized analytics if you prefer.
+            </li>
+          </ul>
+
+          <H2>Questions</H2>
+          <P>
+            We welcome feedback on our privacy practices. If you have any questions,
+            concerns, or complaints, contact us at <Mail />.
+          </P>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## What

Supports the SES production-access re-appeal (transactional-first). Adds a public privacy policy so the appeal can point to a real policy page.

- **`src/pages/privacy.tsx`** (new) — privacy policy at `/privacy`. Content verified against the actual stack: OAuth (GitHub/Google/Discord) + email-password (bcrypt), Vercel Speed Insights as sole analytics (no ad/cross-site tracking), providers Vercel/Neon/Cloudflare/AWS/Zoho, résumé→sponsor sharing.
- **`src/pages/index.tsx`** — "Privacy Policy" link under the sign-up form.
- **`SES-HANDOFF.md`** — working note for the SES effort. **Delete before merging** (not shipping code).

## Verification
- `next lint` — privacy page clean; the two pre-existing `<img>` warnings in `index.tsx` are unrelated to this branch, untouched.
- `prettier --check` — passes (privacy page reformatted in `7c05390`).

## Reviewer notes / open decisions
- **Résumé→sponsor sharing** is disclosed as notice, not explicit opt-in consent — confirm that matches org legal posture.
- `privacy.tsx` "Third-party sign-in" section lists OAuth only; email/password sits under "Primary data" — optionally add a line for completeness.
- `/privacy` must be **deployed live** before the appeal draft can claim a live privacy policy (until then keep the softened line).