### PR TITLE
feat(email): sync Cloudflare suppressions to DB (mark bounced)

### DIFF
--- a/.github/workflows/sync-cf-suppression.yml
+++ b/.github/workflows/sync-cf-suppression.yml
@@ -1,0 +1,51 @@
+name: Sync Cloudflare Suppressions
+
+# Pulls Cloudflare Email Sending's suppression list (hard bounces + spam
+# complaints) and marks matching email_subscriber rows as bounced, so the
+# campaign drip never re-sends to a known-bad address. Idempotent + safe to run
+# repeatedly. Keeps our DB list clean, which protects the bounce rate over time.
+#
+#   - Scheduled runs always apply.
+#   - Manual run: Actions -> this workflow -> Run workflow. Untick "apply" for a
+#     dry run that only reports what would be marked.
+
+on:
+  schedule:
+    - cron: "0 12 * * *" # daily at 12:00 UTC (~8am ET)
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Write bouncedAt (unticked = dry run)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: sync-cf-suppression
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    environment: Production
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      CLOUDFLARE_EMAIL_API_TOKEN: ${{ secrets.CLOUDFLARE_EMAIL_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      SKIP_ENV_VALIDATION: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci
+
+      - name: Sync suppressions
+        env:
+          # Scheduled runs always apply; manual runs honor the checkbox.
+          APPLY: ${{ github.event_name == 'schedule' && 'true' || inputs.apply }}
+        run: |
+          set -o pipefail
+          args=()
+          [ "$APPLY" = "true" ] && args+=(--apply)
+          npx tsx scripts/sync-cf-suppression.ts "${args[@]}"

--- a/scripts/sync-cf-suppression.ts
+++ b/scripts/sync-cf-suppression.ts
@@ -1,0 +1,114 @@
+import { inArray, isNull } from "drizzle-orm";
+import { db } from "~/server/db";
+import { emailSubscribers } from "~/server/db/schema";
+import { env } from "~/env";
+
+// Pulls Cloudflare Email Sending's suppression list (hard bounces + spam
+// complaints) and marks the matching email_subscriber rows as bounced, so the
+// campaign drip — which excludes rows with a bouncedAt via selectEligible —
+// never re-sends to a known-bad address. Cloudflare already suppresses these on
+// its side; this keeps our own DB in sync. Idempotent: only rows not already
+// marked are touched, so it is safe to run on a schedule.
+//
+// Usage:  npx tsx scripts/sync-cf-suppression.ts           # dry run (default)
+//         npx tsx scripts/sync-cf-suppression.ts --apply    # write bouncedAt
+
+const ENDPOINT = `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/email/sending/suppressions`;
+
+interface Suppression {
+  email: string;
+  reason: string;
+}
+
+/** Fetch every suppressed address from Cloudflare, following cursor pagination. */
+export async function fetchSuppressions(): Promise<Suppression[]> {
+  const items: Suppression[] = [];
+  let cursor: string | undefined;
+  do {
+    const url = new URL(ENDPOINT);
+    url.searchParams.set("per_page", "1000");
+    if (cursor) url.searchParams.set("cursor", cursor);
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${env.CLOUDFLARE_EMAIL_API_TOKEN}` },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Cloudflare suppressions API ${res.status}: ${await res.text()}`,
+      );
+    }
+    const json = (await res.json()) as {
+      result?: Suppression[];
+      result_info?: { next_cursor?: string | null };
+    };
+    for (const s of json.result ?? []) {
+      if (s.email) items.push({ email: s.email, reason: s.reason });
+    }
+    cursor = json.result_info?.next_cursor ?? undefined;
+  } while (cursor);
+  return items;
+}
+
+/**
+ * Given the suppressed addresses and the not-yet-bounced subscribers, return the
+ * subscriber ids to mark. Matching is case-insensitive so it survives any casing
+ * differences between the sent address and the stored row.
+ */
+export function idsToMark(
+  suppressedEmails: string[],
+  subscribers: { id: number; email: string }[],
+): number[] {
+  const suppressed = new Set(suppressedEmails.map((e) => e.toLowerCase()));
+  return subscribers
+    .filter((s) => suppressed.has(s.email.toLowerCase()))
+    .map((s) => s.id);
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+
+  const suppressions = await fetchSuppressions();
+  console.log(
+    `Fetched ${suppressions.length} suppressed address(es) from Cloudflare.`,
+  );
+  if (suppressions.length === 0) {
+    console.log("Nothing to sync.");
+    return;
+  }
+
+  const active = await db
+    .select({ id: emailSubscribers.id, email: emailSubscribers.email })
+    .from(emailSubscribers)
+    .where(isNull(emailSubscribers.bouncedAt));
+
+  const ids = idsToMark(
+    suppressions.map((s) => s.email),
+    active,
+  );
+
+  console.log(
+    `${ids.length} subscriber(s) match Cloudflare suppressions and are not yet marked bounced.`,
+  );
+  const emailById = new Map(active.map((s) => [s.id, s.email]));
+  ids.forEach((id) => console.log(`  ${emailById.get(id)}`));
+
+  if (!apply) {
+    console.log("DRY RUN — pass --apply to write bouncedAt.");
+    return;
+  }
+  if (ids.length === 0) return;
+
+  await db
+    .update(emailSubscribers)
+    .set({ bouncedAt: new Date() })
+    .where(inArray(emailSubscribers.id, ids));
+  console.log(`Marked ${ids.length} subscriber(s) as bounced.`);
+}
+
+if (process.argv[1]?.includes("sync-cf-suppression")) {
+  main()
+    .then(() => process.exit(0))
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## What
Adds `scripts/sync-cf-suppression.ts` + a daily **Sync Cloudflare Suppressions** workflow. Pulls Cloudflare Email Sending's suppression list (hard bounces + complaints) and marks matching `email_subscriber` rows `bouncedAt`.

## Why
Our bounce rate spiked and Cloudflare flagged it (risk of a sending pause). Cloudflare already suppresses bad addresses on its side, but our DB didn't know — so the drip could keep attempting them and the list stayed dirty. This keeps our DB in sync so the drip (`selectEligible` excludes `bouncedAt`) never re-sends to a known-bad address.

## Behavior
- **Mark, not delete** — reversible; consistent with the drip's own bounce handling.
- **Dry-run by default**; `--apply` (and scheduled runs) write.
- **Idempotent** — only not-yet-marked rows are touched. Daily cron + manual dispatch (with a dry-run checkbox).

## Verification
- `tsc --noEmit`: clean
- YAML: valid
- prettier / build-and-test: via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)