### PR TITLE
feat(scripts): export email_subscriber list to CSV for bulk verification

### DIFF
--- a/scripts/export-subscribers.ts
+++ b/scripts/export-subscribers.ts
@@ -1,0 +1,48 @@
+import { and, isNull } from "drizzle-orm";
+import { db } from "~/server/db";
+import { emailSubscribers } from "~/server/db/schema";
+
+// Exports the sendable email_subscriber list (hw11 + hw12 alumni — not
+// unsubscribed, not already bounced) as CSV to stdout, for bulk email
+// verification / list cleaning before a re-engagement campaign. The
+// preregistrations table is intentionally excluded: those addresses are
+// validated at signup and assumed clean.
+//
+//   npx tsx scripts/export-subscribers.ts > subscribers.csv
+//
+// Status is written to stderr so stdout stays a clean CSV you can redirect.
+// The `source` column lets you filter to just hw11 or hw12 before uploading.
+
+function csvField(value: string): string {
+  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+async function main() {
+  const rows = await db
+    .select({
+      email: emailSubscribers.email,
+      source: emailSubscribers.source,
+    })
+    .from(emailSubscribers)
+    .where(
+      and(
+        isNull(emailSubscribers.unsubscribedAt),
+        isNull(emailSubscribers.bouncedAt),
+      ),
+    );
+
+  process.stderr.write(`Exporting ${rows.length} subscriber(s) to CSV...\n`);
+  process.stdout.write("email,source\n");
+  for (const r of rows) {
+    process.stdout.write(`${csvField(r.email)},${csvField(r.source)}\n`);
+  }
+}
+
+if (process.argv[1]?.includes("export-subscribers")) {
+  main()
+    .then(() => process.exit(0))
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## What
Adds `scripts/export-subscribers.ts` — dumps the sendable `email_subscriber` list (hw11 + hw12 alumni) to CSV for bulk email verification before a re-engagement campaign.

```
npx tsx scripts/export-subscribers.ts > subscribers.csv
```

## Details
- **Excludes** unsubscribed + already-bounced rows (no point verifying known-dead).
- **Excludes** the `preregistrations` table — those are validated at signup and assumed clean.
- Includes a `source` column so hw11/hw12 can be filtered before upload.
- CSV to stdout, status to stderr → clean redirect.

## Flow
export → upload cleaned list to Kickbox/NeverBounce → send to `deliverable` → (optional) suppression sync marks the dead ones back in the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)