### PR TITLE
fix(preregistration): friendlier 'already subscribed' message

### DIFF
--- a/src/server/api/routers/preregistration.ts
+++ b/src/server/api/routers/preregistration.ts
@@ -54,7 +54,8 @@ export const preregistrationRouter = createTRPCRouter({
         if (Boolean(existingPreregistration) || Boolean(existingSubscriber)) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "Pre-registration with that email already exists.",
+            message:
+              "You're already signed up for Hack Western updates. No need to register again.",
           });
         }
 


### PR DESCRIPTION
## What
The signup form rejected an already-known email with **"Pre-registration with that email already exists."** — thrown when the email is in `preregistrations` **or** `email_subscribers` (including the imported past applicants).

Now: **"You're already signed up for Hack Western updates. No need to register again."**

## Why
Imported alumni/students are in `email_subscriber`, so if they hit the signup form they'd see an error-sounding message. This reads as intended (they're already on the list), not a failure.

No behavior change — same CONFLICT, friendlier copy. Tests assert it throws (not the text), so unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)