### PR TITLE
chore(drip): ramp to ~150/day until Aug 20, then auto-revert

### DIFF
--- a/.github/workflows/send-campaign.yml
+++ b/.github/workflows/send-campaign.yml
@@ -45,7 +45,7 @@ jobs:
       CLOUDFLARE_EMAIL_API_TOKEN: ${{ secrets.CLOUDFLARE_EMAIL_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       SKIP_ENV_VALIDATION: "1"
-      CHUNK: "9" # ~9/run × 11 runs/day = 99/day — deliberately under 100/day for this drip, well within the 200/day CF account quota shared with transactional confirmations
+      CHUNK: "9" # base ~99/day; temporarily ramped to ~154/day (CHUNK 14) until 2026-08-20 in the run step, then auto-reverts. Stays within the 200/day account quota shared with transactional.
       SOURCE: "hw12" # cohort filter — start with hw12 (fresher/engaged); switch to "hw11" once reputation holds, or "" for all sources
       START: "2026-07-30T00:00:00Z" # campaign kickoff; gates re-sends (must precede first send)
     steps:
@@ -73,6 +73,8 @@ jobs:
           ONLY: ${{ inputs.only }}
         run: |
           set -o pipefail
+          # Temporary ramp: ~150/day (CHUNK 14) until the Aug 20 reveal, then auto-revert to base ~99/day.
+          if [[ "$(date -u +%F)" < "2026-08-20" ]]; then CHUNK=14; fi
           args=(--chunk="$CHUNK" --start="$START")
           [ -n "$SOURCE" ] && args+=(--source="$SOURCE")
           [ -n "$FLAG" ] && args+=("$FLAG")


### PR DESCRIPTION
## What
Temporarily bumps the drip from ~99/day to **~154/day** (`CHUNK` 9 → 14, × 11 runs) **until 2026-08-20**, then **auto-reverts** to ~99/day via a date check in the run step.

## Why
The drip audience is already-subscribed, so it generates no new-signup confirmations. New transactional volume stays low until the Aug 20 reveal — so there's quota headroom now to push faster. On/after Aug 20 the reveal drives signups, and transactional needs the 200/day room back, so it steps down automatically.

- Reputation is Healthy (0% bounce), list is verified/cleaned → 150/day is safe + gentle.
- No forgetting: the `if [[ $(date -u +%F) < "2026-08-20" ]]` self-reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)