### PR TITLE
fix(promo): keep top cloud on-screen through loop

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -113,7 +113,7 @@ export default function Home() {
         </div>
       </div>
       <div
-        className="cloud-scroll-right pointer-events-none absolute left-[-12vw] top-[10vh] w-[55vw]"
+        className="cloud-scroll-right cloud-scroll-right-from-left pointer-events-none absolute left-[-12vw] top-[10vh] w-[55vw]"
         aria-hidden="true"
       >
         <Image
@@ -131,7 +131,7 @@ export default function Home() {
           width={4096}
           height={1576}
           quality={65}
-          className="absolute right-[100vw] top-0 h-auto w-full"
+          className="cloud-scroll-right-from-left-copy absolute top-0 h-auto w-full"
           sizes="55vw"
         />
       </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -196,6 +196,15 @@ html {
     }
   }
 
+  @keyframes cloud-scroll-right-from-left {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(calc(100vw + 12vw));
+    }
+  }
+
   @media (prefers-reduced-motion: no-preference) {
     .cloud-scroll-left {
       animation: cloud-scroll-left 95s linear 5s infinite;
@@ -205,9 +214,17 @@ html {
       animation: cloud-scroll-right 70s linear 5s infinite;
     }
 
+    .cloud-scroll-right-from-left {
+      animation: cloud-scroll-right-from-left 70s linear 5s infinite;
+    }
+
     .cloud-scroll-right-slow {
       animation: cloud-scroll-right 95s linear 5s infinite;
     }
+  }
+
+  .cloud-scroll-right-from-left-copy {
+    right: calc(100vw + 12vw);
   }
 
   @supports (-moz-appearance: none) {


### PR DESCRIPTION
Account for the cloud's initial 12vw offset so it fully exits before the animation resets.

closes #775 

# Quick Overview of Changes

- restyled a bit to make it not cut off

https://github.com/user-attachments/assets/ef9c87df-b477-43f6-ae55-ac148bb9afc0


# Checklist

- [ ] If any frontend changes were made, include a screenshot/demo in the overview
- [ ] Checked all uses of changed component(s)/function(s)
- [ ] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [ ] Check that CI is passing.
- [ ] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@lucianlavric @JasmineGu2
