### PR TITLE
feat(cheat-check): add the automated sweep engine and worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,7 @@ HACK_END=""
 # Project submission deadline (ISO 8601 UTC, e.g. 2026-11-22T20:00:00Z).
 # Submissions after this are marked "late". Leave empty for no deadline.
 PROJECT_SUBMISSION_DEADLINE=""
+
+# Bearer token guarding /api/cheat-check/sweep. The sweep worker re-invokes
+# itself with this, so automated sweeps are disabled while it is unset.
+CHEAT_SWEEP_SECRET=""

--- a/drizzle/0012_faulty_cable.sql
+++ b/drizzle/0012_faulty_cable.sql
@@ -1,0 +1,32 @@
+CREATE TYPE "public"."cheat_sweep_item_status" AS ENUM('pending', 'running', 'done', 'failed');--> statement-breakpoint
+CREATE TYPE "public"."cheat_sweep_status" AS ENUM('running', 'completed', 'failed');--> statement-breakpoint
+CREATE TYPE "public"."cheat_sweep_trigger" AS ENUM('queue_drain', 'manual');--> statement-breakpoint
+CREATE TABLE "cheat_check_sweep_item" (
+	"sweep_id" integer NOT NULL,
+	"team_id" varchar(255) NOT NULL,
+	"status" "cheat_sweep_item_status" DEFAULT 'pending' NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"error" text,
+	"updated_at" timestamp (3) DEFAULT now() NOT NULL,
+	CONSTRAINT "cheat_check_sweep_item_sweep_id_team_id_pk" PRIMARY KEY("sweep_id","team_id")
+);
+--> statement-breakpoint
+CREATE TABLE "cheat_check_sweep" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"status" "cheat_sweep_status" DEFAULT 'running' NOT NULL,
+	"triggered_by" "cheat_sweep_trigger" NOT NULL,
+	"started_at" timestamp (3) DEFAULT now() NOT NULL,
+	"last_heartbeat_at" timestamp (3) DEFAULT now() NOT NULL,
+	"finished_at" timestamp (3),
+	"total_teams" integer DEFAULT 0 NOT NULL,
+	"hacker_checks_done" boolean DEFAULT false NOT NULL,
+	"force_rerun" boolean DEFAULT false NOT NULL,
+	"rate_limited_until" timestamp (3),
+	"error" text
+);
+--> statement-breakpoint
+ALTER TABLE "cheat_check_sweep_item" ADD CONSTRAINT "cheat_check_sweep_item_sweep_id_cheat_check_sweep_id_fk" FOREIGN KEY ("sweep_id") REFERENCES "public"."cheat_check_sweep"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cheat_check_sweep_item" ADD CONSTRAINT "cheat_check_sweep_item_team_id_team_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."team"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "cheat_check_sweep_item_claim_idx" ON "cheat_check_sweep_item" USING btree ("sweep_id","status");--> statement-breakpoint
+CREATE UNIQUE INDEX "cheat_check_sweep_active_idx" ON "cheat_check_sweep" USING btree ("status") WHERE status = 'running';--> statement-breakpoint
+CREATE INDEX "cheat_check_sweep_finished_at_idx" ON "cheat_check_sweep" USING btree ("finished_at");

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2588 @@
+{
+  "id": "f3abd954-b3ae-46cf-a430-6d9a5f4f91dc",
+  "prevId": "b5f817ee-91b5-4d84-b89b-dfbd2d567d8e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IN_PROGRESS'"
+        },
+        "avatar_colour": {
+          "name": "avatar_colour",
+          "type": "avatar_colour",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_face": {
+          "name": "avatar_face",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_left_hand": {
+          "name": "avatar_left_hand",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_right_hand": {
+          "name": "avatar_right_hand",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_hat": {
+          "name": "avatar_hat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_residence": {
+          "name": "country_of_residence",
+          "type": "country",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year_of_study": {
+          "name": "year_of_study",
+          "type": "year_of_study",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "major": {
+          "name": "major",
+          "type": "major",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shirt_size": {
+          "name": "shirt_size",
+          "type": "shirt_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_restrictions": {
+          "name": "dietary_restrictions",
+          "type": "dietary_restrictions",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_restrictions_other": {
+          "name": "dietary_restrictions_other",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_of_hackathons": {
+          "name": "num_of_hackathons",
+          "type": "num_of_hackathons",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question1": {
+          "name": "question1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question2": {
+          "name": "question2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question3": {
+          "name": "question3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_link": {
+          "name": "github_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedin_link": {
+          "name": "linkedin_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "devpost_link": {
+          "name": "devpost_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resume_link": {
+          "name": "resume_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_link": {
+          "name": "other_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agree_code_of_conduct": {
+          "name": "agree_code_of_conduct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_share_with_sponsors": {
+          "name": "agree_share_with_sponsors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_share_with_mlh": {
+          "name": "agree_share_with_mlh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_emails_from_mlh": {
+          "name": "agree_emails_from_mlh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_will_be_18": {
+          "name": "agree_will_be_18",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "underrep_group": {
+          "name": "underrep_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ethnicity": {
+          "name": "ethnicity",
+          "type": "race/ethnicity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sexual_orientation": {
+          "name": "sexual_orientation",
+          "type": "sexual_orientation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canvas_data": {
+          "name": "canvas_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"paths\":[],\"timestamp\":0,\"version\":\"\"}'::jsonb"
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_relationship": {
+          "name": "emergency_contact_relationship",
+          "type": "emergency_contact_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone_number": {
+          "name": "emergency_contact_phone_number",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transportation_method": {
+          "name": "transportation_method",
+          "type": "transportation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_user_id_user_id_fk": {
+          "name": "application_user_id_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cheat_check_sweep_item": {
+      "name": "cheat_check_sweep_item",
+      "schema": "",
+      "columns": {
+        "sweep_id": {
+          "name": "sweep_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cheat_sweep_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cheat_check_sweep_item_claim_idx": {
+          "name": "cheat_check_sweep_item_claim_idx",
+          "columns": [
+            {
+              "expression": "sweep_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cheat_check_sweep_item_sweep_id_cheat_check_sweep_id_fk": {
+          "name": "cheat_check_sweep_item_sweep_id_cheat_check_sweep_id_fk",
+          "tableFrom": "cheat_check_sweep_item",
+          "tableTo": "cheat_check_sweep",
+          "columnsFrom": [
+            "sweep_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cheat_check_sweep_item_team_id_team_id_fk": {
+          "name": "cheat_check_sweep_item_team_id_team_id_fk",
+          "tableFrom": "cheat_check_sweep_item",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cheat_check_sweep_item_sweep_id_team_id_pk": {
+          "name": "cheat_check_sweep_item_sweep_id_team_id_pk",
+          "columns": [
+            "sweep_id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cheat_check_sweep": {
+      "name": "cheat_check_sweep",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cheat_sweep_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "cheat_sweep_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_teams": {
+          "name": "total_teams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hacker_checks_done": {
+          "name": "hacker_checks_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "force_rerun": {
+          "name": "force_rerun",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limited_until": {
+          "name": "rate_limited_until",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cheat_check_sweep_active_idx": {
+          "name": "cheat_check_sweep_active_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cheat_check_sweep_finished_at_idx": {
+          "name": "cheat_check_sweep_finished_at_idx",
+          "columns": [
+            {
+              "expression": "finished_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.day_of_registration": {
+      "name": "day_of_registration",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signed_in_at": {
+          "name": "signed_in_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "day_of_registration_user_id_user_id_fk": {
+          "name": "day_of_registration_user_id_user_id_fk",
+          "tableFrom": "day_of_registration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_subscriber": {
+      "name": "email_subscriber",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_subscriber_email_unique": {
+          "name": "email_subscriber_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "email_subscriber_unsubscribe_token_unique": {
+          "name": "email_subscriber_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hacker_check_result": {
+      "name": "hacker_check_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_type": {
+          "name": "check_type",
+          "type": "hacker_check_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "checked_by_user_id": {
+          "name": "checked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manual_override": {
+          "name": "manual_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hacker_check_user_idx": {
+          "name": "hacker_check_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hacker_check_unique_idx": {
+          "name": "hacker_check_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hacker_check_result_user_id_user_id_fk": {
+          "name": "hacker_check_result_user_id_user_id_fk",
+          "tableFrom": "hacker_check_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hacker_check_result_checked_by_user_id_user_id_fk": {
+          "name": "hacker_check_result_checked_by_user_id_user_id_fk",
+          "tableFrom": "hacker_check_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "checked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judge": {
+      "name": "judge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "judge_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'organizer'"
+        },
+        "track": {
+          "name": "track",
+          "type": "track[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marks_count": {
+          "name": "marks_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "marks_sum": {
+          "name": "marks_sum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "marks_squared_sum": {
+          "name": "marks_squared_sum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_id_user_id_fk": {
+          "name": "judge_id_user_id_fk",
+          "tableFrom": "judge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judging_queue": {
+      "name": "judging_queue",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "seen_judges": {
+          "name": "seen_judges",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rounds_remaining": {
+          "name": "rounds_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "judging_queue_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "current_judge_id": {
+          "name": "current_judge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "judging_queue_priority_idx": {
+          "name": "judging_queue_priority_idx",
+          "columns": [
+            {
+              "expression": "rounds_remaining",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "enqueued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "judging_queue_current_judge_idx": {
+          "name": "judging_queue_current_judge_idx",
+          "columns": [
+            {
+              "expression": "current_judge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "judging_queue_team_id_team_id_fk": {
+          "name": "judging_queue_team_id_team_id_fk",
+          "tableFrom": "judging_queue",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judging_queue_current_judge_id_judge_id_fk": {
+          "name": "judging_queue_current_judge_id_judge_id_fk",
+          "tableFrom": "judging_queue",
+          "tableTo": "judge",
+          "columnsFrom": [
+            "current_judge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judging_skip": {
+      "name": "judging_skip",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_id": {
+          "name": "judge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judging_skip_team_id_team_id_fk": {
+          "name": "judging_skip_team_id_team_id_fk",
+          "tableFrom": "judging_skip",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judging_skip_judge_id_judge_id_fk": {
+          "name": "judging_skip_judge_id_judge_id_fk",
+          "tableFrom": "judging_skip",
+          "tableTo": "judge",
+          "columnsFrom": [
+            "judge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "judging_skip_team_id_judge_id_pk": {
+          "name": "judging_skip_team_id_judge_id_pk",
+          "columns": [
+            "team_id",
+            "judge_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preregistration": {
+      "name": "preregistration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "preregistration_email_unique": {
+          "name": "preregistration_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "preregistration_unsubscribe_token_unique": {
+          "name": "preregistration_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reset_password_token": {
+      "name": "reset_password_token",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reset_password_token_userId_user_id_fk": {
+          "name": "reset_password_token_userId_user_id_fk",
+          "tableFrom": "reset_password_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_user_id": {
+          "name": "applicant_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "originality_rating": {
+          "name": "originality_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "technicality_rating": {
+          "name": "technicality_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "passion_rating": {
+          "name": "passion_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "referral": {
+          "name": "referral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "applicant_user_id_idx": {
+          "name": "applicant_user_id_idx",
+          "columns": [
+            {
+              "expression": "applicant_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reviewer_user_id_user_id_fk": {
+          "name": "review_reviewer_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_applicant_user_id_application_user_id_fk": {
+          "name": "review_applicant_user_id_application_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicant_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_applicant_user_id_user_id_fk": {
+          "name": "review_applicant_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "applicant_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_reviewer_user_id_applicant_user_id_pk": {
+          "name": "review_reviewer_user_id_applicant_user_id_pk",
+          "columns": [
+            "reviewer_user_id",
+            "applicant_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_item": {
+      "name": "scavenger_hunt_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scavenger_hunt_item_code_unique": {
+          "name": "scavenger_hunt_item_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_redemption": {
+      "name": "scavenger_hunt_redemption",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "redemption_user_idx": {
+          "name": "redemption_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scavenger_hunt_redemption_user_id_user_id_fk": {
+          "name": "scavenger_hunt_redemption_user_id_user_id_fk",
+          "tableFrom": "scavenger_hunt_redemption",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scavenger_hunt_redemption_reward_id_scavenger_hunt_reward_id_fk": {
+          "name": "scavenger_hunt_redemption_reward_id_scavenger_hunt_reward_id_fk",
+          "tableFrom": "scavenger_hunt_redemption",
+          "tableTo": "scavenger_hunt_reward",
+          "columnsFrom": [
+            "reward_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_reward": {
+      "name": "scavenger_hunt_reward",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_points": {
+          "name": "cost_points",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_scan": {
+      "name": "scavenger_hunt_scan",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanner_id": {
+          "name": "scanner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scan_user_idx": {
+          "name": "scan_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scan_scanner_idx": {
+          "name": "scan_scanner_idx",
+          "columns": [
+            {
+              "expression": "scanner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scavenger_hunt_scan_user_id_user_id_fk": {
+          "name": "scavenger_hunt_scan_user_id_user_id_fk",
+          "tableFrom": "scavenger_hunt_scan",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scavenger_hunt_scan_scanner_id_user_id_fk": {
+          "name": "scavenger_hunt_scan_scanner_id_user_id_fk",
+          "tableFrom": "scavenger_hunt_scan",
+          "tableTo": "user",
+          "columnsFrom": [
+            "scanner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scavenger_hunt_scan_item_id_scavenger_hunt_item_id_fk": {
+          "name": "scavenger_hunt_scan_item_id_scavenger_hunt_item_id_fk",
+          "tableFrom": "scavenger_hunt_scan",
+          "tableTo": "scavenger_hunt_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scavenger_hunt_scan_user_id_item_id_pk": {
+          "name": "scavenger_hunt_scan_user_id_item_id_pk",
+          "columns": [
+            "user_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_check_result": {
+      "name": "team_check_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_type": {
+          "name": "check_type",
+          "type": "team_check_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "checked_by_user_id": {
+          "name": "checked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manual_override": {
+          "name": "manual_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_check_team_idx": {
+          "name": "team_check_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_check_unique_idx": {
+          "name": "team_check_unique_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_check_result_team_id_team_id_fk": {
+          "name": "team_check_result_team_id_team_id_fk",
+          "tableFrom": "team_check_result",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_check_result_checked_by_user_id_user_id_fk": {
+          "name": "team_check_result_checked_by_user_id_user_id_fk",
+          "tableFrom": "team_check_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "checked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_mark": {
+      "name": "team_mark",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_id": {
+          "name": "judge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_type": {
+          "name": "round_type",
+          "type": "round_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_mark_team_idx": {
+          "name": "team_mark_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_mark_judge_idx": {
+          "name": "team_mark_judge_idx",
+          "columns": [
+            {
+              "expression": "judge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_mark_team_id_team_id_fk": {
+          "name": "team_mark_team_id_team_id_fk",
+          "tableFrom": "team_mark",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_mark_judge_id_judge_id_fk": {
+          "name": "team_mark_judge_id_judge_id_fk",
+          "tableFrom": "team_mark",
+          "tableTo": "judge",
+          "columnsFrom": [
+            "judge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(6)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "devpost_url": {
+          "name": "devpost_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_status": {
+          "name": "submission_status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "track[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_github_usernames": {
+          "name": "member_github_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_devpost_usernames": {
+          "name": "member_devpost_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_created_at_idx": {
+          "name": "team_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hacker'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scavenger_hunt_earned": {
+          "name": "scavenger_hunt_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "scavenger_hunt_balance": {
+          "name": "scavenger_hunt_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "user_scavenger_hunt_earned_idx": {
+          "name": "user_scavenger_hunt_earned_idx",
+          "columns": [
+            {
+              "expression": "scavenger_hunt_earned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_scavenger_hunt_balance_idx": {
+          "name": "user_scavenger_hunt_balance_idx",
+          "columns": [
+            {
+              "expression": "scavenger_hunt_balance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_team_id_idx": {
+          "name": "user_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_team_id_team_id_fk": {
+          "name": "user_team_id_team_id_fk",
+          "tableFrom": "user",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_token": {
+      "name": "verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_token_identifier_token_pk": {
+          "name": "verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "IN_PROGRESS",
+        "PENDING_REVIEW",
+        "IN_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED",
+        "DECLINED",
+        "CONFIRMED"
+      ]
+    },
+    "public.avatar_colour": {
+      "name": "avatar_colour",
+      "schema": "public",
+      "values": [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple",
+        "pink"
+      ]
+    },
+    "public.cheat_sweep_item_status": {
+      "name": "cheat_sweep_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "done",
+        "failed"
+      ]
+    },
+    "public.cheat_sweep_status": {
+      "name": "cheat_sweep_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.cheat_sweep_trigger": {
+      "name": "cheat_sweep_trigger",
+      "schema": "public",
+      "values": [
+        "queue_drain",
+        "manual"
+      ]
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "public",
+      "values": [
+        "Canada",
+        "United States",
+        "India",
+        "Other"
+      ]
+    },
+    "public.dietary_restrictions": {
+      "name": "dietary_restrictions",
+      "schema": "public",
+      "values": [
+        "Vegetarian",
+        "Vegan",
+        "Kosher",
+        "Halal",
+        "Other"
+      ]
+    },
+    "public.emergency_contact_relationship": {
+      "name": "emergency_contact_relationship",
+      "schema": "public",
+      "values": [
+        "Parent",
+        "Sibling",
+        "Other family member",
+        "Friend",
+        "Coworker",
+        "Other"
+      ]
+    },
+    "public.race/ethnicity": {
+      "name": "race/ethnicity",
+      "schema": "public",
+      "values": [
+        "American Indian or Alaskan Native",
+        "Asian / Pacific Islander",
+        "Black or African American",
+        "Hispanic",
+        "White / Caucasian",
+        "Multiple ethnicity / Other",
+        "Prefer not to answer"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "Female",
+        "Male",
+        "Non-Binary",
+        "Other",
+        "Prefer not to answer"
+      ]
+    },
+    "public.hacker_check_type": {
+      "name": "hacker_check_type",
+      "schema": "public",
+      "values": [
+        "IS_OF_AGE",
+        "IS_REGISTERED"
+      ]
+    },
+    "public.judge_type": {
+      "name": "judge_type",
+      "schema": "public",
+      "values": [
+        "organizer",
+        "sponsored"
+      ]
+    },
+    "public.judging_queue_status": {
+      "name": "judging_queue_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "assigned"
+      ]
+    },
+    "public.major": {
+      "name": "major",
+      "schema": "public",
+      "values": [
+        "Computer Science",
+        "Computer Engineering",
+        "Software Engineering",
+        "Other Engineering Discipline",
+        "Information Systems",
+        "Information Technology",
+        "System Administration",
+        "Natural Sciences (Biology, Chemistry, Physics, etc.)",
+        "Mathematics/Statistics",
+        "Web Development/Web Design",
+        "Business Administration",
+        "Humanities",
+        "Social Science",
+        "Fine Arts/Performing Arts",
+        "Other"
+      ]
+    },
+    "public.num_of_hackathons": {
+      "name": "num_of_hackathons",
+      "schema": "public",
+      "values": [
+        "0",
+        "1-3",
+        "4-6",
+        "7+"
+      ]
+    },
+    "public.round_type": {
+      "name": "round_type",
+      "schema": "public",
+      "values": [
+        "regular",
+        "sponsored"
+      ]
+    },
+    "public.sexual_orientation": {
+      "name": "sexual_orientation",
+      "schema": "public",
+      "values": [
+        "Asexual / Aromantic",
+        "Pansexual, Demisexual or Omnisexual",
+        "Bisexual",
+        "Queer",
+        "Gay / Lesbian",
+        "Heterosexual / Straight",
+        "Other",
+        "Prefer not to answer"
+      ]
+    },
+    "public.shirt_size": {
+      "name": "shirt_size",
+      "schema": "public",
+      "values": [
+        "S",
+        "M",
+        "L",
+        "XL"
+      ]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "late"
+      ]
+    },
+    "public.team_check_type": {
+      "name": "team_check_type",
+      "schema": "public",
+      "values": [
+        "COMMIT_WITHIN_ALLOTTED_TIME",
+        "ONLY_TEAM_MEMBER_COMMITS",
+        "DEVPOST_MEMBERS_REGISTERED"
+      ]
+    },
+    "public.track": {
+      "name": "track",
+      "schema": "public",
+      "values": [
+        "Best Use of Cohere",
+        "Best Use of AntiGravity",
+        "Best Domain",
+        "General"
+      ]
+    },
+    "public.transportation_method": {
+      "name": "transportation_method",
+      "schema": "public",
+      "values": [
+        "Waterloo",
+        "Toronto",
+        "Hamilton",
+        "None"
+      ]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": [
+        "hacker",
+        "organizer",
+        "sponsor"
+      ]
+    },
+    "public.year_of_study": {
+      "name": "year_of_study",
+      "schema": "public",
+      "values": [
+        "1st",
+        "2nd",
+        "3rd",
+        "4th",
+        "5th+",
+        "N/A",
+        "Prefer not to answer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1786576472066,
       "tag": "0011_apply_judging_triggers",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1786581540130,
+      "tag": "0012_faulty_cable",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/cheat-check-sweep-api.test.ts
+++ b/src/__tests__/cheat-check-sweep-api.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { faker } from "@faker-js/faker";
+import { eq, sql } from "drizzle-orm";
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { db } from "~/server/db";
+import {
+  applications,
+  cheatCheckSweepItems,
+  cheatCheckSweeps,
+  hackerCheckResults,
+  teamCheckResults,
+  teams,
+  users,
+} from "~/server/db/schema";
+
+const SECRET = "test-sweep-secret";
+
+vi.mock("~/env", async (importOriginal) => {
+  const original = await importOriginal<typeof import("~/env")>();
+  const env = original.env as Record<string | symbol, unknown>;
+  return {
+    env: new Proxy(env, {
+      get(target, prop) {
+        if (prop === "HACK_START") return "2025-11-01T00:00:00.000Z";
+        if (prop === "HACK_END") return "2025-11-03T00:00:00.000Z";
+        if (prop === "CHEAT_SWEEP_SECRET") return SECRET;
+        return target[prop];
+      },
+    }),
+  };
+});
+
+const fetchAllCommits = vi.fn();
+const fetchContributors = vi.fn();
+
+vi.mock("~/utils/github", async (importOriginal) => {
+  const original = await importOriginal<typeof import("~/utils/github")>();
+  return {
+    ...original,
+    fetchAllCommits: (owner: string, repo: string) =>
+      fetchAllCommits(owner, repo) as unknown,
+    fetchContributors: (owner: string, repo: string) =>
+      fetchContributors(owner, repo) as unknown,
+  };
+});
+
+const { GithubRateLimitError } = await import("~/utils/github");
+const { SYSTEM_USER_ID } = await import(
+  "~/server/api/utils/cheat-check-runners"
+);
+const handler = (await import("~/pages/api/cheat-check/sweep")).default;
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface CapturedResponse {
+  statusCode: number;
+  body: unknown;
+}
+
+/** Minimal NextApiRequest/Response pair — the handler only touches these bits. */
+async function invoke(
+  opts: { method?: string; secret?: string | null } = {},
+): Promise<CapturedResponse> {
+  const captured: CapturedResponse = { statusCode: 0, body: undefined };
+
+  const secret = opts.secret === undefined ? SECRET : opts.secret;
+  const req = {
+    method: opts.method ?? "POST",
+    headers: secret === null ? {} : { authorization: `Bearer ${secret}` },
+  } as NextApiRequest;
+
+  const res = {
+    status(code: number) {
+      captured.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return this;
+    },
+  } as unknown as NextApiResponse;
+
+  await handler(req, res);
+  return captured;
+}
+
+/**
+ * DevPost is scraped with a bare `fetch`, and so is the worker's self-chain.
+ * One stub serves both: chain requests get an empty 200, DevPost gets a page
+ * listing `john_doe`.
+ */
+function stubFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(
+          `<ul id="collaborators"><li><a href="/john_doe">john_doe</a></li></ul>`,
+        ),
+    }),
+  );
+}
+
+async function makeTeam() {
+  const id = faker.string.alphanumeric(6);
+  await db.insert(teams).values({
+    id,
+    name: `team-${id}`,
+    githubUrl: `https://github.com/owner/${id}`,
+    devpostUrl: `https://devpost.com/software/${id}`,
+    submissionStatus: "submitted",
+    memberGithubUsernames: ["john_doe"],
+    memberDevpostUsernames: ["john_doe"],
+  });
+  return id;
+}
+
+async function makeMember(teamId: string) {
+  const id = faker.string.uuid();
+  await db.insert(users).values({
+    id,
+    name: faker.person.fullName(),
+    email: faker.internet.email(),
+    teamId,
+  });
+  await db.insert(applications).values({
+    userId: id,
+    age: 21,
+    githubLink: "https://github.com/testuser",
+    linkedInLink: "https://linkedin.com/in/testuser",
+    devpostLink: "https://devpost.com/testuser",
+  });
+  return id;
+}
+
+async function startSweep(teamIds: string[]) {
+  const [sweep] = await db
+    .insert(cheatCheckSweeps)
+    .values({ triggeredBy: "manual", totalTeams: teamIds.length })
+    .returning();
+  if (teamIds.length > 0) {
+    await db
+      .insert(cheatCheckSweepItems)
+      .values(teamIds.map((teamId) => ({ sweepId: sweep!.id, teamId })));
+  }
+  return sweep!;
+}
+
+beforeEach(() => {
+  fetchAllCommits.mockResolvedValue([
+    {
+      sha: "abc1234",
+      commit: {
+        author: {
+          name: "john_doe",
+          email: "j@x.com",
+          date: "2025-11-02T12:00:00.000Z",
+        },
+        message: "wip",
+      },
+      author: { login: "john_doe" },
+    },
+  ]);
+  fetchContributors.mockResolvedValue([
+    { login: "john_doe", id: 1, contributions: 5 },
+  ]);
+  stubFetch();
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  await db.delete(cheatCheckSweepItems).where(sql`true`);
+  await db.delete(cheatCheckSweeps).where(sql`true`);
+  await db.delete(teamCheckResults).where(sql`true`);
+  await db.delete(hackerCheckResults).where(sql`true`);
+  await db.delete(applications).where(sql`true`);
+  await db.delete(users).where(sql`true`);
+  await db.delete(teams).where(sql`true`);
+});
+
+// ---------------------------------------------------------------------------
+
+describe("sweep worker auth", () => {
+  test("rejects a non-POST request", async () => {
+    expect((await invoke({ method: "GET" })).statusCode).toBe(405);
+  });
+
+  test("rejects a missing bearer token", async () => {
+    expect((await invoke({ secret: null })).statusCode).toBe(401);
+  });
+
+  test("rejects a wrong bearer token", async () => {
+    expect((await invoke({ secret: "nope" })).statusCode).toBe(401);
+  });
+
+  test("rejects a token of the right length but wrong value", async () => {
+    const sameLength = "x".repeat(SECRET.length);
+    expect((await invoke({ secret: sameLength })).statusCode).toBe(401);
+  });
+});
+
+describe("sweep worker", () => {
+  test("no-ops when no sweep is running", async () => {
+    const res = await invoke();
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ message: "No sweep is running" });
+  });
+
+  test("runs every item, writes results as the system user, and completes", async () => {
+    const teamA = await makeTeam();
+    const teamB = await makeTeam();
+    const member = await makeMember(teamA);
+    const sweep = await startSweep([teamA, teamB]);
+
+    const res = await invoke();
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ message: "Sweep complete", processed: 2 });
+
+    const finished = await db.query.cheatCheckSweeps.findFirst({
+      where: eq(cheatCheckSweeps.id, sweep.id),
+    });
+    expect(finished?.status).toBe("completed");
+    expect(finished?.finishedAt).not.toBeNull();
+    expect(finished?.hackerChecksDone).toBe(true);
+
+    const items = await db.query.cheatCheckSweepItems.findMany({});
+    expect(items.every((i) => i.status === "done")).toBe(true);
+
+    // Three team checks per team, both hacker checks for the one member.
+    const teamRows = await db.query.teamCheckResults.findMany({});
+    expect(teamRows).toHaveLength(6);
+    expect(teamRows.every((r) => r.checkedByUserId === SYSTEM_USER_ID)).toBe(
+      true,
+    );
+
+    const hackerRows = await db.query.hackerCheckResults.findMany({
+      where: eq(hackerCheckResults.userId, member),
+    });
+    expect(hackerRows).toHaveLength(2);
+    expect(hackerRows.every((r) => r.checkedByUserId === SYSTEM_USER_ID)).toBe(
+      true,
+    );
+  });
+
+  test("does nothing while the sweep is rate limited", async () => {
+    const teamId = await makeTeam();
+    const sweep = await startSweep([teamId]);
+    await db
+      .update(cheatCheckSweeps)
+      .set({ rateLimitedUntil: new Date(Date.now() + 60_000) })
+      .where(eq(cheatCheckSweeps.id, sweep.id));
+
+    const res = await invoke();
+    expect(res.body).toMatchObject({ message: "Rate limited" });
+    expect(fetchAllCommits).not.toHaveBeenCalled();
+
+    const item = await db.query.cheatCheckSweepItems.findFirst({});
+    expect(item?.status).toBe("pending");
+    expect(item?.attempts).toBe(0);
+  });
+
+  test("a rate limit mid-run pauses the sweep and refunds the attempt", async () => {
+    const teamId = await makeTeam();
+    const resetAt = new Date(Date.now() + 300_000);
+    fetchAllCommits.mockRejectedValue(
+      new GithubRateLimitError("secondary rate limit", resetAt),
+    );
+    const sweep = await startSweep([teamId]);
+
+    const res = await invoke();
+    expect(res.body).toMatchObject({ message: "Rate limited; sweep paused" });
+
+    const row = await db.query.cheatCheckSweeps.findFirst({
+      where: eq(cheatCheckSweeps.id, sweep.id),
+    });
+    expect(row?.status).toBe("running");
+    expect(row?.rateLimitedUntil?.getTime()).toBe(resetAt.getTime());
+
+    // The team keeps its full retry budget — this was not its fault.
+    const item = await db.query.cheatCheckSweepItems.findFirst({});
+    expect(item?.status).toBe("pending");
+    expect(item?.attempts).toBe(0);
+  });
+
+  test("a failing team is retried, then marked failed with the reason", async () => {
+    const teamId = await makeTeam();
+    fetchAllCommits.mockRejectedValue(new Error("GitHub API error 404"));
+    const sweep = await startSweep([teamId]);
+
+    // A failed item goes back to `pending`, so the invocation's own loop
+    // re-claims it until the budget is spent — no chaining needed here.
+    const res = await invoke();
+
+    expect(res.body).toMatchObject({ message: "Sweep complete" });
+    const item = await db.query.cheatCheckSweepItems.findFirst({});
+    expect(item?.status).toBe("failed");
+    expect(item?.attempts).toBe(3);
+    expect(item?.error).toMatch(/404/);
+
+    const finished = await db.query.cheatCheckSweeps.findFirst({
+      where: eq(cheatCheckSweeps.id, sweep.id),
+    });
+    expect(finished?.status).toBe("completed");
+
+    // The two checks that didn't depend on the commit list still landed.
+    expect(await db.query.teamCheckResults.findMany({})).toHaveLength(2);
+  });
+
+  test("an empty sweep completes rather than spinning", async () => {
+    const sweep = await startSweep([]);
+
+    const res = await invoke();
+    expect(res.body).toMatchObject({ message: "Sweep complete", processed: 0 });
+
+    const finished = await db.query.cheatCheckSweeps.findFirst({
+      where: eq(cheatCheckSweeps.id, sweep.id),
+    });
+    expect(finished?.status).toBe("completed");
+  });
+
+  test("a total network outage still reaches a terminal state instead of chaining forever", async () => {
+    const teamId = await makeTeam();
+    const sweep = await startSweep([teamId]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network is down")),
+    );
+    fetchAllCommits.mockRejectedValue(new Error("network is down"));
+    fetchContributors.mockRejectedValue(new Error("network is down"));
+
+    await invoke();
+
+    const finished = await db.query.cheatCheckSweeps.findFirst({
+      where: eq(cheatCheckSweeps.id, sweep.id),
+    });
+    expect(finished?.status).toBe("completed");
+    const item = await db.query.cheatCheckSweepItems.findFirst({});
+    expect(item?.status).toBe("failed");
+    expect(item?.error).toMatch(/network is down/);
+    expect(await db.query.teamCheckResults.findMany({})).toHaveLength(0);
+  });
+});

--- a/src/env.js
+++ b/src/env.js
@@ -57,6 +57,9 @@ export const env = createEnv({
     // ISO 8601 datetime for the project submission deadline. Submissions after
     // this are marked "late". Unset = no deadline, everything counts as on-time.
     PROJECT_SUBMISSION_DEADLINE: z.string().datetime().optional(),
+    // Bearer token for /api/cheat-check/sweep, which the sweep worker also uses
+    // to re-invoke itself. Leave unset to disable automated sweeps entirely.
+    CHEAT_SWEEP_SECRET: z.string().optional(),
   },
 
   /**
@@ -107,6 +110,7 @@ export const env = createEnv({
     HACK_START: process.env.HACK_START,
     HACK_END: process.env.HACK_END,
     PROJECT_SUBMISSION_DEADLINE: process.env.PROJECT_SUBMISSION_DEADLINE,
+    CHEAT_SWEEP_SECRET: process.env.CHEAT_SWEEP_SECRET,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/pages/api/cheat-check/sweep.ts
+++ b/src/pages/api/cheat-check/sweep.ts
@@ -1,0 +1,209 @@
+/**
+ * The cheat-check sweep worker.
+ *
+ * One invocation claims batches of teams off `cheat_check_sweep_item`, runs
+ * their checks, and — if work remains when its time budget runs out — re-invokes
+ * itself. Vercel Hobby caps functions at 60s and cron at daily granularity, so
+ * chaining is how a sweep of a few hundred teams gets finished at all; the
+ * organizer-facing `cheatCheck.resumeSweep` is the safety net if a link in the
+ * chain dies.
+ *
+ * Unlike every other route here this authenticates with a shared secret rather
+ * than a session: the chained self-invocation has no user behind it.
+ */
+import { timingSafeEqual } from "node:crypto";
+import { type NextApiRequest, type NextApiResponse } from "next";
+import { env } from "~/env";
+import { GithubRateLimitError } from "~/utils/github";
+import {
+  SWEEP_CONCURRENCY,
+  SWEEP_TIME_BUDGET_MS,
+  bumpHeartbeat,
+  claimBatch,
+  countPendingItems,
+  failSweep,
+  finishSweep,
+  getRunningSweep,
+  getSweepMemberIds,
+  kickWorker,
+  markHackerChecksDone,
+  markItemAttemptFailed,
+  markItemDone,
+  releaseItem,
+  setRateLimited,
+} from "~/server/api/utils/cheat-check-sweep";
+import {
+  SYSTEM_USER_ID,
+  ensureSystemUser,
+  runAllTeamChecks,
+  runHackerChecksBulk,
+} from "~/server/api/utils/cheat-check-runners";
+
+export const config = { maxDuration: 60 };
+
+function isAuthorized(req: NextApiRequest): boolean {
+  const secret = env.CHEAT_SWEEP_SECRET;
+  if (!secret) return false;
+
+  const header = req.headers.authorization ?? "";
+  const provided = header.startsWith("Bearer ") ? header.slice(7) : "";
+
+  const a = Buffer.from(provided);
+  const b = Buffer.from(secret);
+  // timingSafeEqual throws on a length mismatch, which would itself leak length.
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/**
+ * Run `task` over `items` with at most `limit` in flight. A shared cursor plus
+ * `limit` workers — enough for what we need, and it keeps the dependency list
+ * where it is.
+ */
+async function withConcurrency<T>(
+  items: T[],
+  limit: number,
+  task: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
+    (async () => {
+      while (cursor < items.length) {
+        const item = items[cursor++]!;
+        await task(item);
+      }
+    })(),
+  );
+  await Promise.all(workers);
+}
+
+function findRateLimit(failures: unknown[]): GithubRateLimitError | undefined {
+  return failures.find(
+    (f): f is GithubRateLimitError => f instanceof GithubRateLimitError,
+  );
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  if (!env.CHEAT_SWEEP_SECRET) {
+    return res
+      .status(503)
+      .json({ message: "Cheat check sweeps are not configured" });
+  }
+
+  if (!isAuthorized(req)) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  const startedAt = Date.now();
+  const sweep = await getRunningSweep();
+  if (!sweep) {
+    return res.status(200).json({ message: "No sweep is running" });
+  }
+
+  if (sweep.rateLimitedUntil && sweep.rateLimitedUntil > new Date()) {
+    return res.status(200).json({
+      message: "Rate limited",
+      until: sweep.rateLimitedUntil.toISOString(),
+    });
+  }
+
+  try {
+    // Every result this worker writes is attributed to the system user, and
+    // `checked_by_user_id` is a NOT NULL foreign key — so make sure the actor
+    // exists rather than trusting whoever created the sweep to have done it.
+    await ensureSystemUser();
+
+    // The hacker checks are pure DB reads over every member of a swept team, so
+    // they run once for the whole sweep instead of per team.
+    if (!sweep.hackerChecksDone) {
+      const memberIds = await getSweepMemberIds(sweep.id);
+      await runHackerChecksBulk(memberIds, SYSTEM_USER_ID, {
+        forceRerun: sweep.forceRerun,
+      });
+      await markHackerChecksDone(sweep.id);
+    }
+
+    let processed = 0;
+    let rateLimit: GithubRateLimitError | undefined;
+
+    while (Date.now() - startedAt < SWEEP_TIME_BUDGET_MS && !rateLimit) {
+      const teamIds = await claimBatch(sweep.id, SWEEP_CONCURRENCY);
+      if (teamIds.length === 0) break;
+
+      await withConcurrency(teamIds, SWEEP_CONCURRENCY, async (teamId) => {
+        try {
+          const { failures } = await runAllTeamChecks(teamId, SYSTEM_USER_ID, {
+            forceRerun: sweep.forceRerun,
+          });
+
+          const limited = findRateLimit(failures);
+          if (limited) {
+            // Not this team's fault — hand it back without charging an attempt.
+            rateLimit ??= limited;
+            await releaseItem(sweep.id, teamId);
+            return;
+          }
+
+          if (failures.length > 0) {
+            await markItemAttemptFailed(
+              sweep.id,
+              teamId,
+              failures
+                .map((f) => (f instanceof Error ? f.message : String(f)))
+                .join("; "),
+            );
+            return;
+          }
+
+          await markItemDone(sweep.id, teamId);
+          processed++;
+        } catch (error) {
+          if (error instanceof GithubRateLimitError) {
+            rateLimit ??= error;
+            await releaseItem(sweep.id, teamId);
+            return;
+          }
+          await markItemAttemptFailed(
+            sweep.id,
+            teamId,
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      });
+
+      await bumpHeartbeat(sweep.id);
+    }
+
+    if (rateLimit) {
+      await setRateLimited(sweep.id, rateLimit.resetAt);
+      return res.status(200).json({
+        message: "Rate limited; sweep paused",
+        processed,
+        until: rateLimit.resetAt.toISOString(),
+      });
+    }
+
+    const remaining = await countPendingItems(sweep.id);
+    if (remaining > 0) {
+      await kickWorker();
+      return res
+        .status(200)
+        .json({ message: "Batch done; chained", processed, remaining });
+    }
+
+    await finishSweep(sweep.id);
+    return res.status(200).json({ message: "Sweep complete", processed });
+  } catch (error) {
+    // Never leave a sweep stuck in `running` because of an unexpected throw.
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("[cheat-check-sweep] worker failed", error);
+    await failSweep(sweep.id, message);
+    return res.status(500).json({ message: "Sweep failed", error: message });
+  }
+}

--- a/src/server/api/utils/cheat-check-sweep.test.ts
+++ b/src/server/api/utils/cheat-check-sweep.test.ts
@@ -1,0 +1,609 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { faker } from "@faker-js/faker";
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "~/server/db";
+import {
+  applications,
+  cheatCheckSweepItems,
+  cheatCheckSweeps,
+  dayOfRegistrations,
+  hackerCheckResults,
+  teamCheckResults,
+  teams,
+  users,
+} from "~/server/db/schema";
+
+// Allow per-test override of the hack window without re-importing the env module
+let _testHackStart: string | undefined = "2025-11-01T00:00:00.000Z";
+let _testHackEnd: string | undefined = "2025-11-03T00:00:00.000Z";
+
+vi.mock("~/env", async (importOriginal) => {
+  const original = await importOriginal<typeof import("~/env")>();
+  const env = original.env as Record<string | symbol, unknown>;
+  return {
+    env: new Proxy(env, {
+      get(target, prop) {
+        if (prop === "HACK_START") return _testHackStart ?? target[prop];
+        if (prop === "HACK_END") return _testHackEnd ?? target[prop];
+        // Left unset on purpose: `kickWorker` then no-ops instead of firing
+        // real HTTP at localhost while the sweep rows are still exercised.
+        if (prop === "CHEAT_SWEEP_SECRET") return undefined;
+        return target[prop];
+      },
+    }),
+  };
+});
+
+// The team checks are the only network-touching part of a sweep. Stub GitHub at
+// the module boundary and DevPost at `fetch`, so the tests exercise the real
+// aggregation, retry and rate-limit paths without leaving the machine.
+const fetchAllCommits = vi.fn();
+const fetchContributors = vi.fn();
+
+vi.mock("~/utils/github", async (importOriginal) => {
+  const original = await importOriginal<typeof import("~/utils/github")>();
+  return {
+    ...original,
+    fetchAllCommits: (owner: string, repo: string) =>
+      fetchAllCommits(owner, repo) as unknown,
+    fetchContributors: (owner: string, repo: string) =>
+      fetchContributors(owner, repo) as unknown,
+  };
+});
+
+const { GithubRateLimitError } = await import("~/utils/github");
+const {
+  SYSTEM_USER_ID,
+  ensureSystemUser,
+  runAllTeamChecks,
+  runHackerChecksBulk,
+} = await import("~/server/api/utils/cheat-check-runners");
+const {
+  MAX_ATTEMPTS,
+  claimBatch,
+  countPendingItems,
+  createSweep,
+  getSweepMemberIds,
+  getSweepStatus,
+  markItemAttemptFailed,
+  markItemDone,
+  releaseItem,
+  releaseOrphanedItems,
+} = await import("~/server/api/utils/cheat-check-sweep");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const IN_WINDOW = "2025-11-02T12:00:00.000Z";
+const OUT_OF_WINDOW = "2025-10-01T12:00:00.000Z";
+
+function commit(date: string, author = "john_doe") {
+  return {
+    sha: faker.string.hexadecimal({ length: 7, prefix: "" }),
+    commit: {
+      author: { name: author, email: `${author}@x.com`, date },
+      message: "wip",
+    },
+    author: { login: author },
+  };
+}
+
+/** A DevPost page whose collaborator list contains `usernames`. */
+function devpostHtml(usernames: string[]) {
+  const items = usernames
+    .map((u) => `<li><a href="/${u}">${u}</a></li>`)
+    .join("");
+  return `<html><body><ul id="collaborators">${items}</ul></body></html>`;
+}
+
+function stubDevpost(usernames: string[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(devpostHtml(usernames)),
+    }),
+  );
+}
+
+async function makeTeam(opts: { members?: string[] } = {}) {
+  const id = faker.string.alphanumeric(6);
+  await db.insert(teams).values({
+    id,
+    name: `team-${id}`,
+    githubUrl: `https://github.com/owner/${id}`,
+    devpostUrl: `https://devpost.com/software/${id}`,
+    submissionStatus: "submitted",
+    memberGithubUsernames: opts.members ?? ["john_doe"],
+    memberDevpostUsernames: opts.members ?? ["john_doe"],
+  });
+  return id;
+}
+
+async function makeUser(
+  opts: {
+    teamId?: string;
+    age?: number;
+    signedIn?: boolean;
+    application?: boolean;
+  } = {},
+) {
+  const id = faker.string.uuid();
+  await db.insert(users).values({
+    id,
+    name: faker.person.fullName(),
+    email: faker.internet.email(),
+    teamId: opts.teamId,
+  });
+
+  if (opts.application !== false) {
+    await db.insert(applications).values({
+      userId: id,
+      age: opts.age ?? 20,
+      githubLink: "https://github.com/testuser",
+      linkedInLink: "https://linkedin.com/in/testuser",
+      devpostLink: "https://devpost.com/testuser",
+    });
+  }
+
+  if (opts.signedIn) {
+    await db
+      .insert(dayOfRegistrations)
+      .values({ userId: id, signedInAt: new Date() });
+  }
+
+  return id;
+}
+
+/** A sweep row plus one pending item per team. */
+async function makeSweepWith(teamIds: string[]) {
+  const [sweep] = await db
+    .insert(cheatCheckSweeps)
+    .values({ triggeredBy: "manual" })
+    .returning();
+  await db
+    .insert(cheatCheckSweepItems)
+    .values(teamIds.map((teamId) => ({ sweepId: sweep!.id, teamId })));
+  return sweep!;
+}
+
+function itemFor(sweepId: number, teamId: string) {
+  return db.query.cheatCheckSweepItems.findFirst({
+    where: and(
+      eq(cheatCheckSweepItems.sweepId, sweepId),
+      eq(cheatCheckSweepItems.teamId, teamId),
+    ),
+  });
+}
+
+beforeEach(async () => {
+  fetchAllCommits.mockResolvedValue([commit(IN_WINDOW)]);
+  fetchContributors.mockResolvedValue([
+    { login: "john_doe", id: 1, contributions: 5 },
+  ]);
+  stubDevpost(["john_doe"]);
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  _testHackStart = "2025-11-01T00:00:00.000Z";
+  _testHackEnd = "2025-11-03T00:00:00.000Z";
+  await db.delete(cheatCheckSweepItems).where(sql`true`);
+  await db.delete(cheatCheckSweeps).where(sql`true`);
+  await db.delete(teamCheckResults).where(sql`true`);
+  await db.delete(hackerCheckResults).where(sql`true`);
+  await db.delete(dayOfRegistrations).where(sql`true`);
+  await db.delete(applications).where(sql`true`);
+  await db.delete(users).where(sql`true`);
+  await db.delete(teams).where(sql`true`);
+});
+
+// ---------------------------------------------------------------------------
+// runAllTeamChecks
+// ---------------------------------------------------------------------------
+
+describe("runAllTeamChecks", () => {
+  test("writes all three results, attributed to the system user", async () => {
+    await ensureSystemUser();
+    const teamId = await makeTeam();
+
+    const { results, failures, skipped } = await runAllTeamChecks(
+      teamId,
+      SYSTEM_USER_ID,
+    );
+
+    expect(failures).toEqual([]);
+    expect(skipped).toEqual([]);
+    expect(results).toHaveLength(3);
+
+    const rows = await db.query.teamCheckResults.findMany({
+      where: eq(teamCheckResults.teamId, teamId),
+    });
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.checkedByUserId === SYSTEM_USER_ID)).toBe(true);
+    expect(rows.every((r) => r.passed)).toBe(true);
+    expect(rows.map((r) => r.checkType).sort()).toEqual([
+      "COMMIT_WITHIN_ALLOTTED_TIME",
+      "DEVPOST_MEMBERS_REGISTERED",
+      "ONLY_TEAM_MEMBER_COMMITS",
+    ]);
+  });
+
+  test("fails the checks it should: out-of-window commits and stranger contributors", async () => {
+    await ensureSystemUser();
+    const teamId = await makeTeam();
+    fetchAllCommits.mockResolvedValue([
+      commit(IN_WINDOW),
+      commit(OUT_OF_WINDOW),
+    ]);
+    fetchContributors.mockResolvedValue([
+      { login: "john_doe", id: 1, contributions: 5 },
+      { login: "a_stranger", id: 2, contributions: 3 },
+    ]);
+
+    await runAllTeamChecks(teamId, SYSTEM_USER_ID);
+
+    const rows = await db.query.teamCheckResults.findMany({
+      where: eq(teamCheckResults.teamId, teamId),
+    });
+    const byType = Object.fromEntries(rows.map((r) => [r.checkType, r]));
+    expect(byType.COMMIT_WITHIN_ALLOTTED_TIME?.passed).toBe(false);
+    expect(byType.ONLY_TEAM_MEMBER_COMMITS?.passed).toBe(false);
+    expect(byType.DEVPOST_MEMBERS_REGISTERED?.passed).toBe(true);
+  });
+
+  test("skips check types that already have a cached result", async () => {
+    await ensureSystemUser();
+    const teamId = await makeTeam();
+    await db.insert(teamCheckResults).values({
+      teamId,
+      checkType: "DEVPOST_MEMBERS_REGISTERED",
+      passed: true,
+      details: {},
+      checkedByUserId: SYSTEM_USER_ID,
+    });
+
+    const { results, skipped } = await runAllTeamChecks(teamId, SYSTEM_USER_ID);
+
+    expect(skipped).toEqual(["DEVPOST_MEMBERS_REGISTERED"]);
+    expect(results).toHaveLength(2);
+    // The cached check never re-scraped DevPost.
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("forceRerun re-runs every check", async () => {
+    await ensureSystemUser();
+    const teamId = await makeTeam();
+    await runAllTeamChecks(teamId, SYSTEM_USER_ID);
+
+    const { results, skipped } = await runAllTeamChecks(
+      teamId,
+      SYSTEM_USER_ID,
+      {
+        forceRerun: true,
+      },
+    );
+
+    expect(skipped).toEqual([]);
+    expect(results).toHaveLength(3);
+    expect(
+      await db.query.teamCheckResults.findMany({
+        where: eq(teamCheckResults.teamId, teamId),
+      }),
+    ).toHaveLength(3);
+  });
+
+  test("one failing check still persists the other two", async () => {
+    await ensureSystemUser();
+    const teamId = await makeTeam();
+    fetchAllCommits.mockRejectedValue(new Error("GitHub API error 404"));
+
+    const { results, failures } = await runAllTeamChecks(
+      teamId,
+      SYSTEM_USER_ID,
+    );
+
+    expect(results).toHaveLength(2);
+    expect(failures).toHaveLength(1);
+    expect((failures[0] as Error).message).toMatch(/404/);
+
+    const rows = await db.query.teamCheckResults.findMany({
+      where: eq(teamCheckResults.teamId, teamId),
+    });
+    expect(rows.map((r) => r.checkType).sort()).toEqual([
+      "DEVPOST_MEMBERS_REGISTERED",
+      "ONLY_TEAM_MEMBER_COMMITS",
+    ]);
+  });
+
+  test("surfaces a rate-limit error through failures rather than throwing", async () => {
+    await ensureSystemUser();
+    const teamId = await makeTeam();
+    const resetAt = new Date(Date.now() + 120_000);
+    fetchAllCommits.mockRejectedValue(
+      new GithubRateLimitError("rate limited", resetAt),
+    );
+
+    const { failures } = await runAllTeamChecks(teamId, SYSTEM_USER_ID);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toBeInstanceOf(GithubRateLimitError);
+    expect(
+      (failures[0] as InstanceType<typeof GithubRateLimitError>).resetAt,
+    ).toEqual(resetAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runHackerChecksBulk
+// ---------------------------------------------------------------------------
+
+describe("runHackerChecksBulk", () => {
+  test("writes both check types for every user in one pass", async () => {
+    await ensureSystemUser();
+    const teamId = await makeTeam();
+    const adult = await makeUser({ teamId, age: 22, signedIn: true });
+    const minor = await makeUser({ teamId, age: 16, signedIn: false });
+
+    const { upserted, skipped } = await runHackerChecksBulk(
+      [adult, minor],
+      SYSTEM_USER_ID,
+    );
+
+    expect(upserted).toBe(4);
+    expect(skipped).toBe(0);
+
+    const rows = await db.query.hackerCheckResults.findMany({});
+    expect(rows).toHaveLength(4);
+    expect(rows.every((r) => r.checkedByUserId === SYSTEM_USER_ID)).toBe(true);
+
+    const byKey = Object.fromEntries(
+      rows.map((r) => [`${r.userId}:${r.checkType}`, r.passed]),
+    );
+    expect(byKey[`${adult}:IS_OF_AGE`]).toBe(true);
+    expect(byKey[`${adult}:IS_REGISTERED`]).toBe(true);
+    expect(byKey[`${minor}:IS_OF_AGE`]).toBe(false);
+    expect(byKey[`${minor}:IS_REGISTERED`]).toBe(false);
+  });
+
+  test("skips users with no application instead of throwing", async () => {
+    await ensureSystemUser();
+    const teamId = await makeTeam();
+    const withApp = await makeUser({ teamId });
+    const withoutApp = await makeUser({ teamId, application: false });
+
+    const { upserted, skipped } = await runHackerChecksBulk(
+      [withApp, withoutApp],
+      SYSTEM_USER_ID,
+    );
+
+    expect(upserted).toBe(2);
+    expect(skipped).toBe(1);
+    expect(
+      await db.query.hackerCheckResults.findMany({
+        where: eq(hackerCheckResults.userId, withoutApp),
+      }),
+    ).toHaveLength(0);
+  });
+
+  test("skips check types already cached, and forceRerun overrides that", async () => {
+    await ensureSystemUser();
+    const teamId = await makeTeam();
+    const userId = await makeUser({ teamId, age: 22 });
+    await db.insert(hackerCheckResults).values({
+      userId,
+      checkType: "IS_OF_AGE",
+      passed: false,
+      details: {},
+      checkedByUserId: SYSTEM_USER_ID,
+    });
+
+    const first = await runHackerChecksBulk([userId], SYSTEM_USER_ID);
+    expect(first.upserted).toBe(1);
+    // The cached (stale) result is left alone.
+    const cached = await db.query.hackerCheckResults.findFirst({
+      where: and(
+        eq(hackerCheckResults.userId, userId),
+        eq(hackerCheckResults.checkType, "IS_OF_AGE"),
+      ),
+    });
+    expect(cached?.passed).toBe(false);
+
+    const second = await runHackerChecksBulk([userId], SYSTEM_USER_ID, {
+      forceRerun: true,
+    });
+    expect(second.upserted).toBe(2);
+    const rerun = await db.query.hackerCheckResults.findFirst({
+      where: and(
+        eq(hackerCheckResults.userId, userId),
+        eq(hackerCheckResults.checkType, "IS_OF_AGE"),
+      ),
+    });
+    expect(rerun?.passed).toBe(true);
+  });
+
+  test("is a no-op for an empty user list", async () => {
+    await expect(runHackerChecksBulk([], SYSTEM_USER_ID)).resolves.toEqual({
+      upserted: 0,
+      skipped: 0,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Work list
+// ---------------------------------------------------------------------------
+
+describe("sweep work list", () => {
+  test("claimBatch claims at most `limit` items and consumes an attempt", async () => {
+    const teamIds = [await makeTeam(), await makeTeam(), await makeTeam()];
+    const sweep = await makeSweepWith(teamIds);
+
+    const claimed = await claimBatch(sweep.id, 2);
+    expect(claimed).toHaveLength(2);
+
+    const rows = await db.query.cheatCheckSweepItems.findMany({});
+    const running = rows.filter((r) => r.status === "running");
+    expect(running).toHaveLength(2);
+    expect(running.every((r) => r.attempts === 1)).toBe(true);
+    expect(rows.filter((r) => r.status === "pending")).toHaveLength(1);
+
+    // The remaining item is handed out next, and nothing is handed out twice.
+    const next = await claimBatch(sweep.id, 2);
+    expect(next).toHaveLength(1);
+    expect(claimed).not.toContain(next[0]);
+    expect(await claimBatch(sweep.id, 2)).toEqual([]);
+  });
+
+  test("a failing item retries up to MAX_ATTEMPTS then goes failed with the error", async () => {
+    const teamId = await makeTeam();
+    const sweep = await makeSweepWith([teamId]);
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      expect(await claimBatch(sweep.id, 1)).toEqual([teamId]);
+      await markItemAttemptFailed(sweep.id, teamId, `boom ${attempt}`);
+
+      const item = await itemFor(sweep.id, teamId);
+      expect(item?.attempts).toBe(attempt);
+      expect(item?.error).toBe(`boom ${attempt}`);
+      expect(item?.status).toBe(attempt < MAX_ATTEMPTS ? "pending" : "failed");
+    }
+
+    // Exhausted: it is no longer offered to a worker.
+    expect(await claimBatch(sweep.id, 1)).toEqual([]);
+    expect(await countPendingItems(sweep.id)).toBe(0);
+  });
+
+  test("releaseItem hands an item back without charging an attempt", async () => {
+    const teamId = await makeTeam();
+    const sweep = await makeSweepWith([teamId]);
+
+    await claimBatch(sweep.id, 1);
+    await releaseItem(sweep.id, teamId);
+
+    const item = await itemFor(sweep.id, teamId);
+    expect(item?.status).toBe("pending");
+    expect(item?.attempts).toBe(0);
+    expect(await claimBatch(sweep.id, 1)).toEqual([teamId]);
+  });
+
+  test("releaseOrphanedItems recovers work abandoned by a dead worker", async () => {
+    const teamIds = [await makeTeam(), await makeTeam()];
+    const sweep = await makeSweepWith(teamIds);
+
+    await claimBatch(sweep.id, 2);
+    expect(await claimBatch(sweep.id, 2)).toEqual([]);
+
+    expect(await releaseOrphanedItems(sweep.id)).toBe(2);
+    expect(await claimBatch(sweep.id, 2)).toHaveLength(2);
+  });
+
+  test("markItemDone clears a previous error and drops the item from the pending count", async () => {
+    const teamId = await makeTeam();
+    const sweep = await makeSweepWith([teamId]);
+
+    await claimBatch(sweep.id, 1);
+    await markItemAttemptFailed(sweep.id, teamId, "transient");
+    await claimBatch(sweep.id, 1);
+    await markItemDone(sweep.id, teamId);
+
+    const item = await itemFor(sweep.id, teamId);
+    expect(item?.status).toBe("done");
+    expect(item?.error).toBeNull();
+    expect(await countPendingItems(sweep.id)).toBe(0);
+  });
+
+  test("getSweepMemberIds returns the members of swept teams only", async () => {
+    const sweptTeam = await makeTeam();
+    const otherTeam = await makeTeam();
+    const inSweep = await makeUser({ teamId: sweptTeam });
+    const notInSweep = await makeUser({ teamId: otherTeam });
+    const teamless = await makeUser();
+    const sweep = await makeSweepWith([sweptTeam]);
+
+    const memberIds = await getSweepMemberIds(sweep.id);
+    expect(memberIds).toEqual([inSweep]);
+    expect(memberIds).not.toContain(notInSweep);
+    expect(memberIds).not.toContain(teamless);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sweep lifecycle
+// ---------------------------------------------------------------------------
+
+describe("createSweep / getSweepStatus", () => {
+  test("builds a work list from eligible teams and reports progress", async () => {
+    await makeTeam();
+    await makeTeam();
+
+    const sweep = await createSweep("manual");
+    expect(sweep?.status).toBe("running");
+    expect(sweep?.totalTeams).toBe(2);
+
+    const before = await getSweepStatus();
+    expect(before?.items).toEqual({
+      pending: 2,
+      running: 0,
+      done: 0,
+      failed: 0,
+    });
+    expect(before?.stalled).toBe(false);
+
+    const [claimed] = await claimBatch(sweep!.id, 1);
+    await markItemDone(sweep!.id, claimed!);
+
+    const after = await getSweepStatus();
+    expect(after?.items).toEqual({
+      pending: 1,
+      running: 0,
+      done: 1,
+      failed: 0,
+    });
+  });
+
+  test("returns null when a sweep is already running", async () => {
+    await makeTeam();
+    expect(await createSweep("manual")).not.toBeNull();
+    expect(await createSweep("queue_drain")).toBeNull();
+  });
+
+  test("completes immediately when no team is eligible", async () => {
+    await db.insert(teams).values({
+      id: faker.string.alphanumeric(6),
+      name: "draft team",
+      submissionStatus: "draft",
+    });
+
+    const sweep = await createSweep("manual");
+    expect(sweep?.status).toBe("completed");
+    expect(sweep?.totalTeams).toBe(0);
+    expect(await db.query.cheatCheckSweepItems.findMany({})).toHaveLength(0);
+  });
+
+  test("reports a running sweep with a stale heartbeat as stalled", async () => {
+    await makeTeam();
+    const sweep = await createSweep("manual");
+    await db
+      .update(cheatCheckSweeps)
+      .set({ lastHeartbeatAt: new Date(Date.now() - 10 * 60_000) })
+      .where(eq(cheatCheckSweeps.id, sweep!.id));
+
+    expect((await getSweepStatus())?.stalled).toBe(true);
+  });
+
+  test("ensureSystemUser is idempotent and creates a non-loginnable organizer", async () => {
+    await ensureSystemUser();
+    await ensureSystemUser();
+
+    const system = await db.query.users.findFirst({
+      where: eq(users.id, SYSTEM_USER_ID),
+    });
+    expect(system?.type).toBe("organizer");
+    expect(system?.password).toBeNull();
+    expect(system?.teamId).toBeNull();
+  });
+});

--- a/src/server/api/utils/cheat-check-sweep.ts
+++ b/src/server/api/utils/cheat-check-sweep.ts
@@ -1,0 +1,467 @@
+/**
+ * Orchestration for the automated cheat-check sweep.
+ *
+ * A sweep runs every team check across every eligible team. It is kicked off
+ * when the judging queue drains — at that point every team has been judged,
+ * submissions are final, and the GitHub/DevPost scrapes aren't competing with
+ * judging for rate limit. Organizers can also start one by hand.
+ *
+ * The work itself is done by `/api/cheat-check/sweep`, which claims batches out
+ * of `cheat_check_sweep_item` and re-invokes itself until the list is empty.
+ * This module owns everything around that: deciding when to start, building the
+ * work list, handing batches out, and reporting progress.
+ */
+import { and, count, desc, eq, gt, inArray, isNotNull, sql } from "drizzle-orm";
+import { db, extractRows } from "~/server/db";
+import {
+  cheatCheckSweepItems,
+  cheatCheckSweeps,
+  judgingQueue,
+  teams,
+  users,
+} from "~/server/db/schema";
+import { env } from "~/env";
+import { ensureSystemUser } from "~/server/api/utils/cheat-check-runners";
+
+/**
+ * How long after a sweep finishes before a drain may start another. Deleting a
+ * mark re-queues its team (see `deleteMark` in the judging router), so without a
+ * cooldown a single correction would re-drain and re-sweep.
+ */
+export const SWEEP_COOLDOWN_MINUTES = 30;
+
+/**
+ * How long one worker invocation may spend claiming and processing batches.
+ * Deliberately under the 60s Vercel function ceiling so there is room to write
+ * the heartbeat and chain the next invocation.
+ */
+export const SWEEP_TIME_BUDGET_MS = 45_000;
+
+/**
+ * Teams processed in parallel inside one invocation. Each team costs roughly
+ * three GitHub requests, so six in flight sits at ~18 concurrent requests —
+ * comfortably under GitHub's 100-concurrent secondary limit and ~180 points/min
+ * against its 900/min ceiling.
+ */
+export const SWEEP_CONCURRENCY = 6;
+
+/** How many times a single team may be retried before it is marked failed. */
+export const MAX_ATTEMPTS = 3;
+
+/** A running sweep whose heartbeat is older than this is considered stalled. */
+export const STALLED_HEARTBEAT_MINUTES = 2;
+
+export type SweepRow = typeof cheatCheckSweeps.$inferSelect;
+
+// ---------------------------------------------------------------------------
+// Starting a sweep
+// ---------------------------------------------------------------------------
+
+/**
+ * Teams a sweep will check.
+ *
+ * Note this is deliberately stricter than `loadQueue`'s predicate in the judging
+ * router, which filters on submission status alone. The team checks scrape both
+ * GitHub and DevPost, and `requireSubmission` throws without those URLs, so a
+ * team missing either would only ever produce failed items.
+ */
+function eligibleTeamsFilter() {
+  return and(
+    inArray(teams.submissionStatus, ["submitted", "late"]),
+    isNotNull(teams.githubUrl),
+    isNotNull(teams.devpostUrl),
+  );
+}
+
+/** The sweep currently `running`, if there is one. */
+export async function getRunningSweep(): Promise<SweepRow | undefined> {
+  return db.query.cheatCheckSweeps.findFirst({
+    where: eq(cheatCheckSweeps.status, "running"),
+  });
+}
+
+/**
+ * Create a sweep and its work list.
+ *
+ * Returns null when another sweep is already running — either because we saw it
+ * here, or because the `cheat_check_sweep_active_idx` partial unique index
+ * rejected the insert (two judges submitting their final marks at the same
+ * instant). Either way the caller has nothing to do.
+ */
+export async function createSweep(
+  triggeredBy: "queue_drain" | "manual",
+  opts: { forceRerun?: boolean } = {},
+): Promise<SweepRow | null> {
+  await ensureSystemUser();
+
+  const eligible = await db
+    .select({ id: teams.id })
+    .from(teams)
+    .where(eligibleTeamsFilter());
+
+  let sweep: SweepRow | undefined;
+  try {
+    [sweep] = await db
+      .insert(cheatCheckSweeps)
+      .values({
+        triggeredBy,
+        forceRerun: opts.forceRerun ?? false,
+        totalTeams: eligible.length,
+      })
+      .returning();
+  } catch (error) {
+    if (isUniqueViolation(error)) return null;
+    throw error;
+  }
+
+  if (!sweep) return null;
+
+  if (eligible.length > 0) {
+    await db
+      .insert(cheatCheckSweepItems)
+      .values(eligible.map((t) => ({ sweepId: sweep.id, teamId: t.id })));
+  } else {
+    // Nothing to do — don't leave an empty sweep sitting in `running` forever.
+    await finishSweep(sweep.id);
+    return { ...sweep, status: "completed" as const };
+  }
+
+  return sweep;
+}
+
+/**
+ * Start a sweep if the judging queue has just drained.
+ *
+ * Called fire-and-forget from `judging.me.submitTeamMark`, so it must never
+ * throw: a cheat-check problem is not a reason to fail a judge's mark.
+ */
+export async function maybeTriggerSweepOnDrain(): Promise<void> {
+  try {
+    const [queued] = await db.select({ value: count() }).from(judgingQueue);
+    if ((queued?.value ?? 0) > 0) return;
+
+    if (await getRunningSweep()) return;
+
+    const cooldownStart = new Date(
+      Date.now() - SWEEP_COOLDOWN_MINUTES * 60_000,
+    );
+    const recent = await db.query.cheatCheckSweeps.findFirst({
+      where: gt(cheatCheckSweeps.finishedAt, cooldownStart),
+    });
+    if (recent) return;
+
+    const sweep = await createSweep("queue_drain");
+    if (sweep && sweep.status === "running") await kickWorker();
+  } catch (error) {
+    console.error("[cheat-check-sweep] failed to trigger on drain", error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Working the queue
+// ---------------------------------------------------------------------------
+
+/**
+ * Claim up to `limit` pending teams for this worker, marking them `running` and
+ * consuming one attempt each.
+ *
+ * `FOR UPDATE SKIP LOCKED` is the same pattern `pickNextTeam` uses in the
+ * judging router: a second worker (a chained invocation that overlapped, or an
+ * organizer-triggered resume) skips past the locked rows instead of blocking or
+ * double-processing them.
+ */
+export async function claimBatch(
+  sweepId: number,
+  limit: number,
+): Promise<string[]> {
+  const claimed = await db.execute<{ team_id: string }>(sql`
+    UPDATE cheat_check_sweep_item
+    SET status = 'running', attempts = attempts + 1, updated_at = NOW()
+    WHERE (sweep_id, team_id) IN (
+      SELECT sweep_id, team_id
+      FROM cheat_check_sweep_item
+      WHERE sweep_id = ${sweepId} AND status = 'pending'
+      ORDER BY team_id
+      LIMIT ${limit}
+      FOR UPDATE SKIP LOCKED
+    )
+    RETURNING team_id
+  `);
+
+  return extractRows<{ team_id: string }>(claimed).map((r) => r.team_id);
+}
+
+export async function markItemDone(
+  sweepId: number,
+  teamId: string,
+): Promise<void> {
+  await db
+    .update(cheatCheckSweepItems)
+    .set({ status: "done", error: null, updatedAt: new Date() })
+    .where(itemKey(sweepId, teamId));
+}
+
+/**
+ * Record a failed attempt. The item goes back to `pending` for another worker to
+ * pick up, unless it has already burned its attempt budget — then it is `failed`
+ * with the reason kept for the organizer to look at.
+ */
+export async function markItemAttemptFailed(
+  sweepId: number,
+  teamId: string,
+  error: string,
+): Promise<void> {
+  await db
+    .update(cheatCheckSweepItems)
+    .set({
+      // The cast is required: a bare CASE yields `text`, which Postgres won't
+      // assign to an enum column.
+      status: sql`(CASE WHEN ${cheatCheckSweepItems.attempts} >= ${MAX_ATTEMPTS} THEN 'failed' ELSE 'pending' END)::cheat_sweep_item_status`,
+      error,
+      updatedAt: new Date(),
+    })
+    .where(itemKey(sweepId, teamId));
+}
+
+/**
+ * Put an item back without charging it an attempt. Used when the sweep was
+ * turned away for rate-limiting rather than for anything wrong with the team.
+ */
+export async function releaseItem(
+  sweepId: number,
+  teamId: string,
+): Promise<void> {
+  await db
+    .update(cheatCheckSweepItems)
+    .set({
+      status: "pending",
+      attempts: sql`GREATEST(${cheatCheckSweepItems.attempts} - 1, 0)`,
+      updatedAt: new Date(),
+    })
+    .where(itemKey(sweepId, teamId));
+}
+
+/** Reset items abandoned mid-flight by a worker that died. */
+export async function releaseOrphanedItems(sweepId: number): Promise<number> {
+  const reset = await db
+    .update(cheatCheckSweepItems)
+    .set({ status: "pending", updatedAt: new Date() })
+    .where(
+      and(
+        eq(cheatCheckSweepItems.sweepId, sweepId),
+        eq(cheatCheckSweepItems.status, "running"),
+      ),
+    )
+    .returning({ teamId: cheatCheckSweepItems.teamId });
+
+  return reset.length;
+}
+
+export async function countPendingItems(sweepId: number): Promise<number> {
+  const [row] = await db
+    .select({ value: count() })
+    .from(cheatCheckSweepItems)
+    .where(
+      and(
+        eq(cheatCheckSweepItems.sweepId, sweepId),
+        inArray(cheatCheckSweepItems.status, ["pending", "running"]),
+      ),
+    );
+
+  return row?.value ?? 0;
+}
+
+/** The user ids of every member of a team in this sweep. */
+export async function getSweepMemberIds(sweepId: number): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ id: users.id })
+    .from(users)
+    .innerJoin(
+      cheatCheckSweepItems,
+      eq(cheatCheckSweepItems.teamId, users.teamId),
+    )
+    .where(eq(cheatCheckSweepItems.sweepId, sweepId));
+
+  return rows.map((r) => r.id);
+}
+
+// ---------------------------------------------------------------------------
+// Sweep lifecycle
+// ---------------------------------------------------------------------------
+
+export async function bumpHeartbeat(sweepId: number): Promise<void> {
+  await db
+    .update(cheatCheckSweeps)
+    .set({ lastHeartbeatAt: new Date() })
+    .where(eq(cheatCheckSweeps.id, sweepId));
+}
+
+export async function markHackerChecksDone(sweepId: number): Promise<void> {
+  await db
+    .update(cheatCheckSweeps)
+    .set({ hackerChecksDone: true, lastHeartbeatAt: new Date() })
+    .where(eq(cheatCheckSweeps.id, sweepId));
+}
+
+export async function setRateLimited(
+  sweepId: number,
+  until: Date,
+): Promise<void> {
+  await db
+    .update(cheatCheckSweeps)
+    .set({ rateLimitedUntil: until, lastHeartbeatAt: new Date() })
+    .where(eq(cheatCheckSweeps.id, sweepId));
+}
+
+export async function finishSweep(sweepId: number): Promise<void> {
+  await db
+    .update(cheatCheckSweeps)
+    .set({
+      status: "completed",
+      finishedAt: new Date(),
+      lastHeartbeatAt: new Date(),
+    })
+    .where(eq(cheatCheckSweeps.id, sweepId));
+}
+
+export async function failSweep(sweepId: number, error: string): Promise<void> {
+  await db
+    .update(cheatCheckSweeps)
+    .set({
+      status: "failed",
+      error,
+      finishedAt: new Date(),
+      lastHeartbeatAt: new Date(),
+    })
+    .where(eq(cheatCheckSweeps.id, sweepId));
+}
+
+// ---------------------------------------------------------------------------
+// Operator surface
+// ---------------------------------------------------------------------------
+
+export interface SweepStatus {
+  sweep: SweepRow;
+  items: Record<"pending" | "running" | "done" | "failed", number>;
+  /** True when the sweep says it's running but its worker has gone quiet. */
+  stalled: boolean;
+}
+
+/** The running sweep, or the most recent one, with its item counts. */
+export async function getSweepStatus(): Promise<SweepStatus | null> {
+  const sweep =
+    (await getRunningSweep()) ??
+    (await db.query.cheatCheckSweeps.findFirst({
+      orderBy: [desc(cheatCheckSweeps.startedAt)],
+    }));
+
+  if (!sweep) return null;
+
+  const grouped = await db
+    .select({ status: cheatCheckSweepItems.status, value: count() })
+    .from(cheatCheckSweepItems)
+    .where(eq(cheatCheckSweepItems.sweepId, sweep.id))
+    .groupBy(cheatCheckSweepItems.status);
+
+  const items = { pending: 0, running: 0, done: 0, failed: 0 };
+  for (const row of grouped) items[row.status] = row.value;
+
+  const stalled =
+    sweep.status === "running" &&
+    sweep.lastHeartbeatAt.getTime() <
+      Date.now() - STALLED_HEARTBEAT_MINUTES * 60_000;
+
+  return { sweep, items, stalled };
+}
+
+/**
+ * Re-kick a stalled or rate-limited sweep. Vercel Hobby cron only runs daily, so
+ * recovery is organizer-driven rather than automatic.
+ */
+export async function resumeSweep(): Promise<{
+  resumed: boolean;
+  released: number;
+}> {
+  const sweep = await getRunningSweep();
+  if (!sweep) return { resumed: false, released: 0 };
+
+  await db
+    .update(cheatCheckSweeps)
+    .set({ rateLimitedUntil: null, lastHeartbeatAt: new Date() })
+    .where(eq(cheatCheckSweeps.id, sweep.id));
+
+  const released = await releaseOrphanedItems(sweep.id);
+  await kickWorker();
+
+  return { resumed: true, released };
+}
+
+// ---------------------------------------------------------------------------
+// Worker invocation
+// ---------------------------------------------------------------------------
+
+function baseUrl(): string {
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  if (env.NEXTAUTH_URL) return env.NEXTAUTH_URL;
+  return "http://localhost:3000";
+}
+
+export function sweepWorkerUrl(): string {
+  return `${baseUrl().replace(/\/$/, "")}/api/cheat-check/sweep`;
+}
+
+/**
+ * Poke the worker route without waiting for it to finish.
+ *
+ * The short abort is deliberate: awaiting briefly guarantees the request is
+ * actually flushed before a serverless process freezes, while not blocking on
+ * the child's whole run. The resulting `AbortError` is the success path.
+ *
+ * No-ops when `CHEAT_SWEEP_SECRET` is unset — the route would reject the call
+ * anyway, and this is also what keeps tests from firing real HTTP at localhost.
+ */
+export async function kickWorker(): Promise<void> {
+  if (!env.CHEAT_SWEEP_SECRET) {
+    console.warn(
+      "[cheat-check-sweep] CHEAT_SWEEP_SECRET is unset; not starting the worker",
+    );
+    return;
+  }
+
+  try {
+    await fetch(sweepWorkerUrl(), {
+      method: "POST",
+      headers: { Authorization: `Bearer ${env.CHEAT_SWEEP_SECRET}` },
+      signal: AbortSignal.timeout(1500),
+    });
+  } catch (error) {
+    // An abort means the request went out and we stopped waiting — expected.
+    if (error instanceof Error && error.name === "AbortError") return;
+    if (error instanceof Error && error.name === "TimeoutError") return;
+    console.error("[cheat-check-sweep] failed to kick the worker", error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function itemKey(sweepId: number, teamId: string) {
+  return and(
+    eq(cheatCheckSweepItems.sweepId, sweepId),
+    eq(cheatCheckSweepItems.teamId, teamId),
+  );
+}
+
+/** Postgres `unique_violation`, however the driver chose to surface it. */
+function isUniqueViolation(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const code = (error as { code?: unknown }).code;
+  if (code === "23505") return true;
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause && (cause as { code?: unknown }).code === "23505") return true;
+  return (
+    error instanceof Error &&
+    error.message.includes("cheat_check_sweep_active_idx")
+  );
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -180,6 +180,34 @@ export const judgingQueueStatusEnum = pgEnum("judging_queue_status", [
 
 export const roundTypeEnum = pgEnum("round_type", ["regular", "sponsored"]);
 
+/**
+ * The lifecycle of an automated cheat-check sweep across every eligible team.
+ */
+export const cheatSweepStatusEnum = pgEnum("cheat_sweep_status", [
+  "running",
+  "completed",
+  "failed",
+]);
+
+/**
+ * What caused a sweep to start — the judging queue draining, or an organizer
+ * kicking one off by hand.
+ */
+export const cheatSweepTriggerEnum = pgEnum("cheat_sweep_trigger", [
+  "queue_drain",
+  "manual",
+]);
+
+/**
+ * The state of a single team's slot in a sweep's work list.
+ */
+export const cheatSweepItemStatusEnum = pgEnum("cheat_sweep_item_status", [
+  "pending",
+  "running",
+  "done",
+  "failed",
+]);
+
 export const trackEnum = pgEnum("track", [
   "Best Use of Cohere",
   "Best Use of AntiGravity",
@@ -824,6 +852,106 @@ export const teamCheckResultsRelations = relations(
     checkedBy: one(users, {
       fields: [teamCheckResults.checkedByUserId],
       references: [users.id],
+    }),
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// Cheat check sweeps
+// ---------------------------------------------------------------------------
+
+/**
+ * One row per automated cheat-check sweep. A sweep is started when the judging
+ * queue drains (or manually by an organizer) and is worked off in slices by
+ * `/api/cheat-check/sweep`, which re-invokes itself until every item is done.
+ *
+ * `lastHeartbeatAt` is bumped after every batch so a sweep whose worker died
+ * mid-flight can be spotted and resumed.
+ */
+export const cheatCheckSweeps = pgTable(
+  "cheat_check_sweep",
+  {
+    id: serial("id").primaryKey(),
+    status: cheatSweepStatusEnum("status").default("running").notNull(),
+    triggeredBy: cheatSweepTriggerEnum("triggered_by").notNull(),
+    startedAt: timestamp("started_at", { mode: "date", precision: 3 })
+      .defaultNow()
+      .notNull(),
+    lastHeartbeatAt: timestamp("last_heartbeat_at", {
+      mode: "date",
+      precision: 3,
+    })
+      .defaultNow()
+      .notNull(),
+    finishedAt: timestamp("finished_at", { mode: "date", precision: 3 }),
+    totalTeams: integer("total_teams").default(0).notNull(),
+    // The two hacker checks are pure DB reads, so they run once per sweep in
+    // bulk rather than per team.
+    hackerChecksDone: boolean("hacker_checks_done").default(false).notNull(),
+    // When false (the default) the sweep skips check types that already have a
+    // cached result.
+    forceRerun: boolean("force_rerun").default(false).notNull(),
+    rateLimitedUntil: timestamp("rate_limited_until", {
+      mode: "date",
+      precision: 3,
+    }),
+    error: text("error"),
+  },
+  (t) => [
+    // Partial unique index: at most one sweep may be `running` at a time. This
+    // is what makes double-triggering impossible (two judges submitting their
+    // final marks near-simultaneously) without application-level locking.
+    uniqueIndex("cheat_check_sweep_active_idx")
+      .on(t.status)
+      .where(sql`status = 'running'`),
+    index("cheat_check_sweep_finished_at_idx").on(t.finishedAt),
+  ],
+);
+
+/**
+ * One row per team in a sweep — the durable work list. It makes a sweep
+ * resumable after a function timeout, caps retries so a permanently broken
+ * repo can't loop forever, and gives per-team error visibility.
+ */
+export const cheatCheckSweepItems = pgTable(
+  "cheat_check_sweep_item",
+  {
+    sweepId: integer("sweep_id")
+      .notNull()
+      .references(() => cheatCheckSweeps.id, { onDelete: "cascade" }),
+    teamId: varchar("team_id", { length: 255 })
+      .notNull()
+      .references(() => teams.id, { onDelete: "cascade" }),
+    status: cheatSweepItemStatusEnum("status").default("pending").notNull(),
+    attempts: integer("attempts").default(0).notNull(),
+    error: text("error"),
+    updatedAt: timestamp("updated_at", { mode: "date", precision: 3 })
+      .defaultNow()
+      .notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.sweepId, t.teamId] }),
+    index("cheat_check_sweep_item_claim_idx").on(t.sweepId, t.status),
+  ],
+);
+
+export const cheatCheckSweepsRelations = relations(
+  cheatCheckSweeps,
+  ({ many }) => ({
+    items: many(cheatCheckSweepItems),
+  }),
+);
+
+export const cheatCheckSweepItemsRelations = relations(
+  cheatCheckSweepItems,
+  ({ one }) => ({
+    sweep: one(cheatCheckSweeps, {
+      fields: [cheatCheckSweepItems.sweepId],
+      references: [cheatCheckSweeps.id],
+    }),
+    team: one(teams, {
+      fields: [cheatCheckSweepItems.teamId],
+      references: [teams.id],
     }),
   }),
 );


### PR DESCRIPTION
## What

A sweep runs every team check across every eligible team, so organizers get a full picture without clicking through teams one at a time.

Nothing triggers a sweep in this PR — that's 4/4. This adds the machinery and the schema.

## How

Vercel Hobby caps functions at 60s, which a few hundred teams won't fit in. `/api/cheat-check/sweep` therefore claims a batch out of `cheat_check_sweep_item`, works it, and re-invokes itself until the list is empty. Progress lives in the database rather than in memory, so a dead link in that chain loses at most one batch and the run can be resumed.

Details worth a reviewer's attention:

- **`cheat_check_sweep_active_idx`** is a partial unique index on `status = 'running'`, so two concurrent starts can't both create a sweep — the loser takes a unique violation and backs off. This is why `createSweep` returns `null` rather than throwing.
- **Batches are claimed with `FOR UPDATE SKIP LOCKED`**, matching `pickNextTeam` in the judging router, so an overlapping worker skips claimed rows instead of double-processing them.
- **Rate limiting is not a failure.** It doesn't consume a team's retry budget and pauses the whole run until the reset time, using the `GithubRateLimitError` from #838.
- **Eligibility is stricter than the judging queue's.** It requires both a GitHub and a DevPost URL, since `requireSubmission` throws without them and such a team could only ever produce failed items.

The worker authenticates with `CHEAT_SWEEP_SECRET` (timing-safe compare) rather than a session, because its own self-invocation has no user behind it. Leaving the secret unset disables automated sweeps.

## Migration

`drizzle/0012_faulty_cable.sql`, generated with `npx drizzle-kit generate` and committed alongside the schema change per the README. Adds `cheat_check_sweep` + `cheat_check_sweep_item`, three enums, and the indexes described above.

## Testing

`npx vitest run` — 258 passed, including new suites for the engine (`cheat-check-sweep.test.ts`) and the worker route (`sweep.test.ts`).

## Note

3/4 in a stack, based on #838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)