### PR TITLE
feat(cheat-check): run a sweep when the judging queue drains

### DIFF
--- a/src/server/api/routers/cheat-check.ts
+++ b/src/server/api/routers/cheat-check.ts
@@ -16,12 +16,19 @@ import {
   findCachedHackerResult,
   findCachedTeamResult,
   hasAllHackerChecks,
+  runAllTeamChecks,
   runCommitWithinAllottedTime,
   runDevpostMembersRegistered,
   runIsOfAge,
   runIsRegistered,
   runOnlyTeamMemberCommits,
 } from "~/server/api/utils/cheat-check-runners";
+import {
+  createSweep,
+  getSweepStatus,
+  kickWorker,
+  resumeSweep,
+} from "~/server/api/utils/cheat-check-sweep";
 
 const userIdInput = z.object({ userId: z.string() });
 const teamIdInput = z.object({ teamId: z.string() });
@@ -155,6 +162,32 @@ export const cheatCheckRouter = createTRPCRouter({
       return { ...result, fromCache: false };
     }),
 
+  /**
+   * Runs every team check for one team and returns them together — the
+   * synchronous counterpart to a sweep, for when an organizer wants one team
+   * looked at now rather than waiting for the queue to drain.
+   *
+   * One failing check (a deleted repo, a DevPost 404) does not discard the
+   * others — `failures` carries the messages for the ones that threw.
+   */
+  runAllTeamChecks: protectedOrganizerProcedure
+    .input(teamIdInput.extend({ forceRerun: z.boolean().default(false) }))
+    .mutation(async ({ input, ctx }) => {
+      const { results, failures, skipped } = await runAllTeamChecks(
+        input.teamId,
+        ctx.session.user.id,
+        { forceRerun: input.forceRerun },
+      );
+
+      return {
+        results,
+        skipped,
+        failures: failures.map((f) =>
+          f instanceof Error ? f.message : String(f),
+        ),
+      };
+    }),
+
   // -------------------------------------------------------------------------
   // Batch helpers
   // -------------------------------------------------------------------------
@@ -278,4 +311,50 @@ export const cheatCheckRouter = createTRPCRouter({
       checks: team.checkResults,
     }));
   }),
+
+  // -------------------------------------------------------------------------
+  // Automated sweeps
+  // -------------------------------------------------------------------------
+
+  /**
+   * Progress of the running sweep, or of the most recent one if none is running.
+   * `stalled` means the worker has gone quiet and the sweep needs resuming.
+   */
+  getSweepStatus: protectedOrganizerProcedure.query(async () => {
+    return getSweepStatus();
+  }),
+
+  /**
+   * Re-kick a stalled or rate-limited sweep: clears the rate-limit stamp, puts
+   * items abandoned by a dead worker back in the queue, and starts a new worker.
+   */
+  resumeSweep: protectedOrganizerProcedure.mutation(async () => {
+    return resumeSweep();
+  }),
+
+  /**
+   * Start a full sweep by hand, without waiting for the judging queue to drain.
+   * Pass forceRerun to re-check teams that already have cached results.
+   */
+  startSweep: protectedOrganizerProcedure
+    .input(
+      z.object({ forceRerun: z.boolean().default(false) }).default({
+        forceRerun: false,
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const sweep = await createSweep("manual", {
+        forceRerun: input.forceRerun,
+      });
+
+      if (!sweep) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "A cheat check sweep is already running",
+        });
+      }
+
+      if (sweep.status === "running") await kickWorker();
+      return sweep;
+    }),
 });

--- a/src/server/api/routers/judging.test.ts
+++ b/src/server/api/routers/judging.test.ts
@@ -7,6 +7,8 @@ import { createInnerTRPCContext } from "~/server/api/trpc";
 import { db } from "~/server/db";
 import { mockOrganizerSession, mockSession } from "~/server/auth";
 import {
+  cheatCheckSweepItems,
+  cheatCheckSweeps,
   judges,
   judgingQueue,
   judgingSkips,
@@ -80,7 +82,33 @@ async function resetAll() {
   await db.delete(judgingSkips).where(sql`true`);
   await db.delete(judgingQueue).where(sql`true`);
   await db.delete(judges).where(sql`true`);
+  // Sweep rows outlive their teams (no FK from sweep -> team), so a leftover
+  // `running` sweep or a recent `finishedAt` would suppress the next drain.
+  await db.delete(cheatCheckSweepItems).where(sql`true`);
+  await db.delete(cheatCheckSweeps).where(sql`true`);
   await db.delete(teams).where(sql`true`);
+}
+
+/**
+ * `maybeTriggerSweepOnDrain` is fired without being awaited so it can't delay a
+ * judge's mark, so the sweep row lands a tick or two after the mutation
+ * resolves. Poll for it rather than racing it.
+ */
+async function waitFor<T>(
+  read: () => Promise<T | undefined>,
+  message: string,
+): Promise<T> {
+  for (let i = 0; i < 50; i++) {
+    const value = await read();
+    if (value !== undefined) return value;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(message);
+}
+
+/** Give the un-awaited drain hook a chance to run before asserting it didn't. */
+async function settleDrainHook() {
+  await new Promise((resolve) => setTimeout(resolve, 100));
 }
 
 // The triggers can't be expressed in Drizzle's schema DSL, so pushSchema
@@ -323,6 +351,160 @@ describe("submitTeamMark", () => {
     expect(row?.seenJudges).toBe(1);
     expect(row?.status).toBe("waiting");
     expect(row?.currentJudgeId).toBeNull();
+  });
+});
+
+/* ---------- cheat-check sweep on queue drain ---------- */
+
+describe("cheat check sweep trigger", () => {
+  /** A team that is submitted but has no repo/DevPost links to scrape. */
+  async function makeUnsubmittableTeam() {
+    const id = faker.string.alphanumeric(6);
+    await db.insert(teams).values({
+      id,
+      name: `team-${id}`,
+      devpostUrl: null,
+      githubUrl: null,
+      submissionStatus: "submitted",
+    });
+    return id;
+  }
+
+  test("draining the queue starts exactly one sweep with an item per eligible team", async () => {
+    const org = await makeOrganizer();
+    const teamId = await makeTeam();
+    const otherTeamId = await makeTeam();
+    await org.caller.judging.admin.loadQueue({ roundsPerTeam: 1 });
+
+    const j = await makeJudge();
+    await j.caller.judging.me.getNextTeam();
+    await j.caller.judging.me.submitTeamMark({ teamId, score: 70 });
+
+    // Queue still has the second team, so no sweep yet.
+    await settleDrainHook();
+    expect(await db.query.cheatCheckSweeps.findMany({})).toHaveLength(0);
+
+    await j.caller.judging.me.getNextTeam();
+    await j.caller.judging.me.submitTeamMark({
+      teamId: otherTeamId,
+      score: 90,
+    });
+
+    const sweep = await waitFor(
+      async () => (await db.query.cheatCheckSweeps.findMany({}))[0],
+      "expected a sweep after the queue drained",
+    );
+    expect(sweep.status).toBe("running");
+    expect(sweep.triggeredBy).toBe("queue_drain");
+    expect(sweep.totalTeams).toBe(2);
+
+    const items = await db.query.cheatCheckSweepItems.findMany({});
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.teamId).sort()).toEqual(
+      [teamId, otherTeamId].sort(),
+    );
+    expect(items.every((i) => i.status === "pending")).toBe(true);
+  });
+
+  test("teams without a repo or DevPost link get no sweep item", async () => {
+    const org = await makeOrganizer();
+    const teamId = await makeTeam();
+    const linkless = await makeUnsubmittableTeam();
+    await org.caller.judging.admin.loadQueue({ roundsPerTeam: 1 });
+
+    const j = await makeJudge();
+    // Both teams are queued (loadQueue only looks at submission status), so
+    // both must be marked before the queue drains.
+    for (let i = 0; i < 2; i++) {
+      const { team } = await j.caller.judging.me.getNextTeam();
+      await j.caller.judging.me.submitTeamMark({ teamId: team.id, score: 70 });
+    }
+
+    const sweep = await waitFor(
+      async () => (await db.query.cheatCheckSweeps.findMany({}))[0],
+      "expected a sweep after the queue drained",
+    );
+    expect(sweep.totalTeams).toBe(1);
+
+    const items = await db.query.cheatCheckSweepItems.findMany({});
+    expect(items.map((i) => i.teamId)).toEqual([teamId]);
+    expect(items.map((i) => i.teamId)).not.toContain(linkless);
+  });
+
+  test("a sweep that finished recently suppresses the next drain", async () => {
+    const org = await makeOrganizer();
+    const teamId = await makeTeam();
+    await org.caller.judging.admin.loadQueue({ roundsPerTeam: 1 });
+
+    // A sweep that completed a minute ago, well inside the 30 minute cooldown.
+    await db.insert(cheatCheckSweeps).values({
+      triggeredBy: "manual",
+      status: "completed",
+      finishedAt: new Date(Date.now() - 60_000),
+    });
+
+    const j = await makeJudge();
+    await j.caller.judging.me.getNextTeam();
+    await j.caller.judging.me.submitTeamMark({ teamId, score: 70 });
+
+    await settleDrainHook();
+    const sweeps = await db.query.cheatCheckSweeps.findMany({});
+    expect(sweeps).toHaveLength(1);
+    expect(sweeps[0]?.triggeredBy).toBe("manual");
+    expect(await db.query.cheatCheckSweepItems.findMany({})).toHaveLength(0);
+  });
+
+  test("an already-running sweep is not duplicated by a drain", async () => {
+    const org = await makeOrganizer();
+    const teamId = await makeTeam();
+    await org.caller.judging.admin.loadQueue({ roundsPerTeam: 1 });
+
+    await db
+      .insert(cheatCheckSweeps)
+      .values({ triggeredBy: "manual", status: "running" });
+
+    const j = await makeJudge();
+    await j.caller.judging.me.getNextTeam();
+    await j.caller.judging.me.submitTeamMark({ teamId, score: 70 });
+
+    await settleDrainHook();
+    expect(await db.query.cheatCheckSweeps.findMany({})).toHaveLength(1);
+  });
+
+  test("the partial unique index permits only one running sweep", async () => {
+    await db
+      .insert(cheatCheckSweeps)
+      .values({ triggeredBy: "manual", status: "running" });
+
+    await expect(
+      db
+        .insert(cheatCheckSweeps)
+        .values({ triggeredBy: "queue_drain", status: "running" }),
+    ).rejects.toThrow();
+
+    // A finished sweep alongside a running one is fine — the index is partial.
+    await expect(
+      db
+        .insert(cheatCheckSweeps)
+        .values({ triggeredBy: "manual", status: "completed" }),
+    ).resolves.toBeDefined();
+  });
+
+  test("a drain with no eligible teams completes the sweep immediately", async () => {
+    const org = await makeOrganizer();
+    const linkless = await makeUnsubmittableTeam();
+    await org.caller.judging.admin.loadQueue({ roundsPerTeam: 1 });
+
+    const j = await makeJudge();
+    await j.caller.judging.me.getNextTeam();
+    await j.caller.judging.me.submitTeamMark({ teamId: linkless, score: 70 });
+
+    const sweep = await waitFor(
+      async () => (await db.query.cheatCheckSweeps.findMany({}))[0],
+      "expected a sweep after the queue drained",
+    );
+    expect(sweep.status).toBe("completed");
+    expect(sweep.totalTeams).toBe(0);
   });
 });
 

--- a/src/server/api/routers/judging.ts
+++ b/src/server/api/routers/judging.ts
@@ -15,6 +15,7 @@ import {
   teams,
   users,
 } from "~/server/db/schema";
+import { maybeTriggerSweepOnDrain } from "~/server/api/utils/cheat-check-sweep";
 import {
   type AddJudgeInput,
   addJudgesSchema,
@@ -508,6 +509,12 @@ export const judgingRouter = createTRPCRouter({
             input.score,
             roundType,
           );
+
+          // `submitMark` has committed, so `trg_team_mark_autoqueue` has
+          // already removed the team from the queue if it was fully judged —
+          // only now is the queue count meaningful. Deliberately not awaited:
+          // the cheat-check sweep must never delay or fail a judge's mark.
+          void maybeTriggerSweepOnDrain();
         }, "Failed to submit team mark");
       }),
 


### PR DESCRIPTION
## What

Wires the sweep engine from #839 to its trigger, and adds the organizer-facing endpoints.

## How

A drained judging queue is the right moment for a full sweep: every team has been judged, submissions are final, and the GitHub/DevPost scrapes are no longer competing with judging for rate limit.

- **Fired from `submitTeamMark`, after the mark commits.** `trg_team_mark_autoqueue` has already removed the team by then, so the queue count is meaningful. Ordering matters — checking before the commit would read a stale count.
- **Deliberately not awaited, and never throws.** A cheat-check problem is not a reason to fail a judge's mark.
- **30-minute cooldown.** Deleting a mark re-queues its team (see `deleteMark`), so without it a single scoring correction would re-drain and re-sweep.

## New API surface

This PR is where the stack's new tRPC endpoints land — #838 is a pure refactor and #839 adds only the worker's HTTP route. All are `protectedOrganizerProcedure`:

| procedure | purpose |
|---|---|
| `getSweepStatus` | progress of the running sweep, or the most recent one; reports `stalled` when the worker has gone quiet |
| `resumeSweep` | clears the rate-limit stamp, requeues items abandoned by a dead worker, starts a new worker |
| `startSweep` | kick one off by hand without waiting for a drain |
| `runAllTeamChecks` | synchronous counterpart to a sweep, for one team now rather than waiting for a drain |

`resumeSweep` is the safety net for the self-invocation chain: if a link dies, the heartbeat goes stale and an organizer can restart it without losing completed work.

There are no frontend consumers of `cheatCheck.*` yet, so nothing downstream needs regenerating — but these four are new surface and should be reviewed as such.

## Testing

`npx vitest run` — 269 passed. Six new `judging.test.ts` cases cover the drain trigger: exactly one sweep per drain with an item per eligible team, ineligible teams excluded, cooldown suppression, no duplication when one is already running, the partial unique index under concurrency, and an empty eligible set completing immediately.

Verified with `npx next build` and `npx prettier --check ./src` as well.

## Note

4/4 in a stack, based on #839.

🤖 Generated with [Claude Code](https://claude.com/claude-code)