### PR TITLE
feat(email): route re-engagement drip through Mailjet (drip-only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,13 @@ GOOGLE_CLIENT_SECRET=""
 DISCORD_CLIENT_ID=""
 DISCORD_CLIENT_SECRET=""
 
-# Cloudflare Email Service
+# Mailjet — drip transport only (scripts/send-campaign.ts), Send API v3.1.
+# Transactional email stays on Cloudflare below. Use the marketing subaccount's
+# API key + secret. Leave blank locally; the drip guards on them at runtime.
+MAILJET_API_KEY=""
+MAILJET_SECRET_KEY=""
+
+# Cloudflare Email Service — transactional transport (signup/verify/reset)
 CLOUDFLARE_EMAIL_API_TOKEN=""
 CLOUDFLARE_ACCOUNT_ID=""
 

--- a/.github/workflows/send-campaign.yml
+++ b/.github/workflows/send-campaign.yml
@@ -42,10 +42,12 @@ jobs:
     environment: Production
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      CLOUDFLARE_EMAIL_API_TOKEN: ${{ secrets.CLOUDFLARE_EMAIL_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Drip sends via Mailjet (scripts/send-campaign.ts). Transactional email
+      # stays on Cloudflare, so this workflow needs only the Mailjet creds.
+      MAILJET_API_KEY: ${{ secrets.MAILJET_API_KEY }}
+      MAILJET_SECRET_KEY: ${{ secrets.MAILJET_SECRET_KEY }}
       SKIP_ENV_VALIDATION: "1"
-      CHUNK: "14" # steady-state ~154/day (14 × 11 runs); the run step overrides this with a warm-up curve until the subdomain is warmed. Stays within the 200/day account quota shared with transactional.
+      CHUNK: "14" # steady-state ~154/day (14 × 11 runs); the run step overrides this with a warm-up curve until the domain is warmed. Under the Mailjet free 200/day cap, which the drip now owns alone (transactional is on Cloudflare).
       SOURCE: "hw12" # cohort filter — start with hw12 (fresher/engaged); switch to "hw11" once reputation holds, or "" for all sources
       START: "2026-07-30T00:00:00Z" # campaign kickoff; gates re-sends (must precede first send)
     steps:
@@ -73,18 +75,21 @@ jobs:
           ONLY: ${{ inputs.only }}
         run: |
           set -o pipefail
-          # Cold-subdomain warm-up curve. mail.hackwestern.com is a new sending
-          # subdomain with no Gmail reputation, so ramp volume slowly (start low,
-          # ~double weekly) to build reputation instead of tripping spam filters
-          # with a cold high-volume blast. Send daily for consistency; step up
-          # only while bounces/complaints stay clean. Dates are UTC; ISO dates
-          # compare correctly as strings. Reverts to the CHUNK env (~154/day)
-          # once past the last band.
+          # New-sending-path warm-up curve. Per Mailjet docs, the shared IP is
+          # already pre-warmed by Mailjet — no IP warm-up needed on this tier.
+          # What IS new is the DOMAIN path: mail.hackwestern.com has zero history
+          # sending *through Mailjet* (Cloudflare reputation does not transfer,
+          # different IPs). So ramp volume gently to build domain reputation
+          # instead of tripping spam filters with a cold blast. Bands reset to
+          # start on the Mailjet cutover (2026-08-15, day 1 = 0 sent). Send daily
+          # for consistency; step up only while bounces/complaints stay clean.
+          # Dates are UTC; ISO dates compare correctly as strings. Reverts to the
+          # CHUNK env (~154/day, under the 200/day cap) once past the last band.
           TODAY="$(date -u +%F)"
-          if   [[ "$TODAY" < "2026-08-14" ]]; then CHUNK=2   # days 1-3  ~22/day
-          elif [[ "$TODAY" < "2026-08-18" ]]; then CHUNK=4   # days 4-7  ~44/day
-          elif [[ "$TODAY" < "2026-08-25" ]]; then CHUNK=7   # week 2    ~77/day
-          elif [[ "$TODAY" < "2026-09-01" ]]; then CHUNK=11  # week 3    ~121/day
+          if   [[ "$TODAY" < "2026-08-18" ]]; then CHUNK=2   # days 1-3   ~22/day
+          elif [[ "$TODAY" < "2026-08-22" ]]; then CHUNK=4   # days 4-7   ~44/day
+          elif [[ "$TODAY" < "2026-08-29" ]]; then CHUNK=7   # week 2     ~77/day
+          elif [[ "$TODAY" < "2026-09-05" ]]; then CHUNK=11  # week 3    ~121/day
           fi                                                 # week 4+   ~154/day (CHUNK env)
           args=(--chunk="$CHUNK" --start="$START")
           [ -n "$SOURCE" ] && args+=(--source="$SOURCE")

--- a/scripts/send-campaign.ts
+++ b/scripts/send-campaign.ts
@@ -1,7 +1,11 @@
 import { and, isNull, or, lt, asc, eq } from "drizzle-orm";
+import { env } from "~/env";
 import { db } from "~/server/db";
 import { emailSubscribers } from "~/server/db/schema";
-import { sendEmail } from "~/server/mail";
+// Drip sends via Mailjet directly (NOT the shared ~/server/mail, which is the
+// Cloudflare transactional transport). Keeping the marketing stream on its own
+// provider isolates its sending reputation from password-reset/verify email.
+import { sendViaMailjet } from "~/server/mail-mailjet";
 import {
   campaignTemplate,
   campaignText,
@@ -135,23 +139,39 @@ async function main() {
     return;
   }
 
+  // Live send needs the Mailjet marketing creds. Fail loud rather than looping
+  // through recipients returning a config error for every one.
+  if (!env.MAILJET_API_KEY || !env.MAILJET_SECRET_KEY) {
+    console.error(
+      "MAILJET_API_KEY / MAILJET_SECRET_KEY not set — cannot send the drip.",
+    );
+    process.exit(1);
+  }
+  const mjCreds = {
+    apiKey: env.MAILJET_API_KEY,
+    secretKey: env.MAILJET_SECRET_KEY,
+  };
+
   let sent = 0,
     bounced = 0,
     failed = 0;
   for (const r of rows) {
     const { subject, html, text, headers } = renderFor(r);
-    const res = await sendEmail({
-      // Bulk campaign sends from an isolated subdomain so a spam/bounce hit
-      // can't poison transactional (password-reset/verify) deliverability on
-      // the root domain. Replies still route to the monitored inbox (reply_to).
-      from: "Hack Western <updates@mail.hackwestern.com>",
-      replyTo: "hello@hackwestern.com",
-      to: r.email,
-      subject,
-      html,
-      text,
-      headers,
-    });
+    const res = await sendViaMailjet(
+      {
+        // Bulk campaign sends from an isolated subdomain so a spam/bounce hit
+        // can't poison transactional (password-reset/verify) deliverability on
+        // the root domain. Replies still route to the monitored inbox (reply_to).
+        from: "Hack Western <updates@mail.hackwestern.com>",
+        replyTo: "hello@hackwestern.com",
+        to: r.email,
+        subject,
+        html,
+        text,
+        headers,
+      },
+      mjCreds,
+    );
     const outcome = classifyResult(res);
     if (outcome === "quota") {
       console.log(`FAIL ${r.email} — ${res.error?.message}`);

--- a/src/env.js
+++ b/src/env.js
@@ -28,6 +28,16 @@ export const env = createEnv({
     GOOGLE_CLIENT_SECRET: z.string(),
     DISCORD_CLIENT_ID: z.string(),
     DISCORD_CLIENT_SECRET: z.string(),
+    // Mailjet (Send API v3.1) — used ONLY by the re-engagement drip
+    // (scripts/send-campaign.ts). Transactional email still sends via
+    // Cloudflare below; keeping the drip on its own transport isolates the
+    // marketing sending reputation from password-reset/verify. Optional at
+    // build time so this compiles before the Mailjet account exists; the drip
+    // guards on them at runtime.
+    MAILJET_API_KEY: z.string().optional(),
+    MAILJET_SECRET_KEY: z.string().optional(),
+    // Cloudflare Email Service — the transactional transport
+    // (signup/verify/reset/application confirmations) via src/server/mail.ts.
     CLOUDFLARE_EMAIL_API_TOKEN: z.string(),
     CLOUDFLARE_ACCOUNT_ID: z.string(),
     // Kickbox email-verification API key (optional). When set, signup emails are
@@ -83,6 +93,8 @@ export const env = createEnv({
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+    MAILJET_API_KEY: process.env.MAILJET_API_KEY,
+    MAILJET_SECRET_KEY: process.env.MAILJET_SECRET_KEY,
     CLOUDFLARE_EMAIL_API_TOKEN:
       process.env.CLOUDFLARE_EMAIL_API_TOKEN ??
       (process.env.NODE_ENV === "test" ? "mock-cf-api-token" : undefined),

--- a/src/server/mail-mailjet.test.ts
+++ b/src/server/mail-mailjet.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { parseAddress, sendViaMailjet } from "~/server/mail-mailjet";
+
+const CREDS = { apiKey: "pub", secretKey: "priv" };
+const BASE = { to: "user@example.com", subject: "Hi", html: "<p>Hi</p>" };
+
+interface MailjetPayload {
+  Messages: {
+    From: { Email: string; Name?: string };
+    To: { Email: string }[];
+    Subject: string;
+    HTMLPart: string;
+    TextPart: string;
+    ReplyTo?: { Email: string };
+    Headers?: Record<string, string>;
+  }[];
+}
+
+/** Stub global fetch and capture what the transport sent. */
+function stubFetch(body: unknown, ok = true, status = 200) {
+  let capturedUrl = "";
+  let capturedAuth = "";
+  let capturedBody = "{}";
+  const fn = vi.fn(
+    (url: string | URL, init?: RequestInit): Promise<Response> => {
+      capturedUrl = String(url);
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      capturedAuth = headers.Authorization ?? "";
+      capturedBody = typeof init?.body === "string" ? init.body : "{}";
+      return Promise.resolve({
+        ok,
+        status,
+        json: () => Promise.resolve(body),
+        text: () =>
+          Promise.resolve(
+            typeof body === "string" ? body : JSON.stringify(body),
+          ),
+      } as Response);
+    },
+  );
+  vi.stubGlobal("fetch", fn);
+  return {
+    url: () => capturedUrl,
+    auth: () => capturedAuth,
+    payload: () => JSON.parse(capturedBody) as MailjetPayload,
+  };
+}
+
+describe("parseAddress", () => {
+  test("splits the display-name form", () => {
+    expect(parseAddress("Hack Western <hello@hackwestern.com>")).toEqual({
+      Email: "hello@hackwestern.com",
+      Name: "Hack Western",
+    });
+  });
+  test("passes through a bare address", () => {
+    expect(parseAddress("hello@hackwestern.com")).toEqual({
+      Email: "hello@hackwestern.com",
+    });
+  });
+});
+
+describe("sendViaMailjet", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  test("success returns the delivered recipients", async () => {
+    stubFetch({
+      Messages: [
+        {
+          Status: "success",
+          To: [{ Email: "user@example.com", MessageID: "1" }],
+        },
+      ],
+    });
+    const res = await sendViaMailjet(BASE, CREDS);
+    expect(res.error).toBeNull();
+    expect(res.data?.delivered).toEqual(["user@example.com"]);
+  });
+
+  test("per-message error surfaces Mailjet's message (HTTP still 200)", async () => {
+    stubFetch({
+      Messages: [
+        { Status: "error", Errors: [{ ErrorMessage: "invalid domain" }] },
+      ],
+    });
+    const res = await sendViaMailjet(BASE, CREDS);
+    expect(res.data).toBeNull();
+    expect(res.error?.message).toContain("invalid domain");
+  });
+
+  test("HTTP error returns the status", async () => {
+    stubFetch("Unauthorized", false, 401);
+    const res = await sendViaMailjet(BASE, CREDS);
+    expect(res.data).toBeNull();
+    expect(res.error?.message).toContain("401");
+  });
+
+  test("network throw is caught", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("down")));
+    const res = await sendViaMailjet(BASE, CREDS);
+    expect(res.data).toBeNull();
+    expect(res.error?.message).toBe("down");
+  });
+
+  test("sends Basic auth + a v3.1 payload with from/replyTo/headers/text", async () => {
+    const cap = stubFetch({
+      Messages: [{ Status: "success", To: [{ Email: "user@example.com" }] }],
+    });
+    await sendViaMailjet(
+      {
+        ...BASE,
+        from: "Hack Western <updates@mail.hackwestern.com>",
+        replyTo: "hello@hackwestern.com",
+        text: "Hi",
+        headers: { "List-Unsubscribe": "<mailto:x>" },
+      },
+      CREDS,
+    );
+    expect(cap.url()).toBe("https://api.mailjet.com/v3.1/send");
+    expect(cap.auth()).toBe(
+      `Basic ${Buffer.from("pub:priv").toString("base64")}`,
+    );
+    const msg = cap.payload().Messages[0]!;
+    expect(msg.From).toEqual({
+      Email: "updates@mail.hackwestern.com",
+      Name: "Hack Western",
+    });
+    expect(msg.To).toEqual([{ Email: "user@example.com" }]);
+    expect(msg.ReplyTo).toEqual({ Email: "hello@hackwestern.com" });
+    expect(msg.Headers).toEqual({ "List-Unsubscribe": "<mailto:x>" });
+    expect(msg.TextPart).toBe("Hi");
+  });
+
+  test("derives TextPart from html when text is omitted", async () => {
+    const cap = stubFetch({
+      Messages: [{ Status: "success", To: [{ Email: "user@example.com" }] }],
+    });
+    await sendViaMailjet({ ...BASE, html: "<p>Hello</p>" }, CREDS);
+    expect(cap.payload().Messages[0]!.TextPart).toBe("Hello");
+  });
+});

--- a/src/server/mail-mailjet.ts
+++ b/src/server/mail-mailjet.ts
@@ -1,0 +1,109 @@
+import type { SendEmailOptions, SendEmailResult } from "./mail";
+
+/** Mailjet API key + secret for the sending (sub)account. */
+export interface MailjetCreds {
+  apiKey: string;
+  secretKey: string;
+}
+
+/** Subset of the Mailjet Send API v3.1 response we care about. */
+interface MailjetV31Response {
+  Messages?: {
+    Status?: string;
+    To?: { Email?: string; MessageID?: string }[];
+    Errors?: { ErrorMessage?: string; ErrorCode?: string }[];
+  }[];
+}
+
+/**
+ * Parse an RFC 5322 display-name address ("Name <email>") into Mailjet's
+ * `{ Email, Name }` object, falling back to a bare `{ Email }`.
+ */
+export function parseAddress(input: string): { Email: string; Name?: string } {
+  const match = /^\s*(.+?)\s*<([^>]+)>\s*$/.exec(input);
+  if (match?.[1] && match[2]) {
+    return { Email: match[2].trim(), Name: match[1].replace(/^"|"$/g, "") };
+  }
+  return { Email: input.trim() };
+}
+
+/**
+ * Sends an outbound email via the Mailjet Send API v3.1.
+ * POST https://api.mailjet.com/v3.1/send — Basic auth (apiKey:secretKey).
+ *
+ * NOTE vs Cloudflare: Mailjet does NOT report permanent bounces synchronously
+ * in the send response — a hard bounce surfaces later via Mailjet's event API /
+ * suppression list. So `bounced` here is always empty; the drip's
+ * send-response bounce marking (scripts/send-campaign.ts classifyResult) goes
+ * quiet on Mailjet and must be replaced by a suppression sync (see the
+ * migration runbook). Mailjet still auto-suppresses known-bad addresses, so no
+ * mail is sent to them.
+ */
+export async function sendViaMailjet(
+  options: SendEmailOptions,
+  creds: MailjetCreds,
+): Promise<SendEmailResult> {
+  const recipients = (
+    Array.isArray(options.to) ? options.to : [options.to]
+  ).map((email) => ({ Email: email }));
+  const from = parseAddress(
+    options.from ?? "Hack Western Team <hello@hackwestern.com>",
+  );
+  const auth = Buffer.from(`${creds.apiKey}:${creds.secretKey}`).toString(
+    "base64",
+  );
+
+  try {
+    const response = await fetch("https://api.mailjet.com/v3.1/send", {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        Messages: [
+          {
+            From: from,
+            To: recipients,
+            Subject: options.subject,
+            HTMLPart: options.html,
+            TextPart: options.text ?? options.html.replace(/<[^>]*>?/gm, ""),
+            ...(options.replyTo ? { ReplyTo: { Email: options.replyTo } } : {}),
+            ...(options.headers ? { Headers: options.headers } : {}),
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error("Mailjet API Error:", response.status, errorBody);
+      return {
+        data: null,
+        error: {
+          message: `Mailjet API error ${response.status}: ${errorBody}`,
+        },
+      };
+    }
+
+    const resData = (await response.json()) as MailjetV31Response;
+    const message = resData.Messages?.[0];
+
+    // Per-message failure surfaces as Status:"error" (HTTP is still 200).
+    if (!message || message.Status !== "success") {
+      const reason =
+        message?.Errors?.[0]?.ErrorMessage ?? "Mailjet send failed";
+      console.error("Mailjet send rejected:", message?.Errors);
+      return { data: null, error: { message: reason } };
+    }
+
+    const delivered = (message.To ?? [])
+      .map((t) => t.Email ?? "")
+      .filter(Boolean);
+    return { data: { delivered, queued: [], bounced: [] }, error: null };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error("Mailjet Fetch Error:", reason);
+    return { data: null, error: { message: reason } };
+  }
+}


### PR DESCRIPTION
## What

Route the HW11/12 → HW13 re-engagement **drip** through the Mailjet Send API v3.1. **Transactional email (signup/verify/reset/application confirmations) stays on Cloudflare** — only the marketing drip moves.

## Why drip-only (not the full cutover)

The full-cutover branch (`feat/email-mailjet-transport`) targets a **paid** Mailjet tier (Essential+, 2 subaccounts) to isolate marketing vs transactional sending reputation. On the current **free** account that isolation is impossible (free = 1 subaccount, 200/day). Running the drip on Mailjet while transactional stays on Cloudflare isolates the two streams *without* paying for multi-subaccount — the transactional stream simply never touches Mailjet.

## Changes

- `scripts/send-campaign.ts` — send via `sendViaMailjet` directly instead of the shared `~/server/mail` transport; guard on Mailjet creds before a live send. `mail.ts` untouched.
- `src/server/mail-mailjet.ts` (+ unit test) — pure Mailjet v3.1 transport (copied from the cutover branch).
- `src/env.js` / `.env.example` — add optional `MAILJET_API_KEY` / `MAILJET_SECRET_KEY`; Cloudflare vars unchanged (still the transactional transport).
- `.github/workflows/send-campaign.yml` — drip workflow uses the Mailjet secrets; warm-up bands reset to the 2026-08-15 cutover.

## Warm-up

Per Mailjet docs, free/Essential tiers send on **shared IPs that Mailjet pre-warms** — no IP warm-up on our side. What is new is the **domain path** (`mail.hackwestern.com` has zero history sending through Mailjet; Cloudflare reputation doesn't transfer). So the workflow keeps a gentle domain ramp, reset to start on cutover day.

## Merging is safe

Scheduled runs stay **dry-run** until the repo variable `CAMPAIGN_LIVE=true`. Nothing sends on merge.

## Prerequisites before arming

- [x] `MAILJET_API_KEY` / `MAILJET_SECRET_KEY` set in the **Production** environment.
- [ ] Authenticate `mail.hackwestern.com` in Mailjet (SPF `include:spf.mailjet.com` + DKIM TXT) — sends bounce/spam without it.
- [ ] Live-fire test: Actions → Run workflow → tick *send* + `only=<an email>`; confirm inbox + SPF/DKIM pass.
- [ ] Arm: `gh variable set CAMPAIGN_LIVE --body true`.

## Verification

- Mailjet transport unit test: 8/8 pass.
- `tsc --noEmit`: clean.

## Rollback

Revert the merge → drip back on Cloudflare. Transactional never moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)