### PR TITLE
fix: stop link scanners from unsubscribing people, and normalize prer…

### DIFF
--- a/src/__tests__/unsubscribe-page.test.ts
+++ b/src/__tests__/unsubscribe-page.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { getServerSideProps } from "~/pages/unsubscribe";
 import * as subs from "~/server/subscribers";
 
@@ -8,21 +8,49 @@ const ctx = (token?: string) =>
   >[0];
 
 describe("unsubscribe getServerSideProps", () => {
-  test("valid token → status ok", async () => {
-    vi.spyOn(subs, "unsubscribeByToken").mockResolvedValue(true);
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // THE IMPORTANT ONE. This page previously unsubscribed inside
+  // getServerSideProps, so a plain GET was a write. Link scanners fetch every URL
+  // in an incoming email, so Microsoft Defender silently unsubscribed people who
+  // had never opened the message: 489 of 497 unsubscribes on the HW13 announcement
+  // landed within two minutes of that recipient's own send.
+  //
+  // If this assertion ever fails, the bug is back.
+  test("GET never writes — only the POST handler unsubscribes", async () => {
+    const write = vi.spyOn(subs, "unsubscribeByToken").mockResolvedValue(true);
+    vi.spyOn(subs, "tokenExists").mockResolvedValue("ready");
+
+    await getServerSideProps(ctx("abc"));
+    await getServerSideProps(ctx());
+    await getServerSideProps(ctx("nope"));
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  test("valid unused token → ready, so the page offers the button", async () => {
+    vi.spyOn(subs, "tokenExists").mockResolvedValue("ready");
     const res = await getServerSideProps(ctx("abc"));
-    expect(res).toEqual({ props: { status: "ok" } });
+    expect(res).toEqual({ props: { status: "ready" } });
+  });
+
+  test("already unsubscribed → already, so the page confirms instead of asking", async () => {
+    vi.spyOn(subs, "tokenExists").mockResolvedValue("already");
+    const res = await getServerSideProps(ctx("abc"));
+    expect(res).toEqual({ props: { status: "already" } });
   });
 
   test("missing token → invalid, no DB call", async () => {
-    const spy = vi.spyOn(subs, "unsubscribeByToken").mockResolvedValue(true);
+    const spy = vi.spyOn(subs, "tokenExists").mockResolvedValue("ready");
     const res = await getServerSideProps(ctx());
     expect(res).toEqual({ props: { status: "invalid" } });
     expect(spy).not.toHaveBeenCalled();
   });
 
   test("unknown token → invalid", async () => {
-    vi.spyOn(subs, "unsubscribeByToken").mockResolvedValue(false);
+    vi.spyOn(subs, "tokenExists").mockResolvedValue("invalid");
     const res = await getServerSideProps(ctx("nope"));
     expect(res).toEqual({ props: { status: "invalid" } });
   });

--- a/src/pages/unsubscribe.tsx
+++ b/src/pages/unsubscribe.tsx
@@ -37,10 +37,14 @@ export default function Unsubscribe({ status }: Props) {
     setBusy(true);
     setFailed(false);
     try {
-      const token = new URLSearchParams(window.location.search).get("token") ?? "";
-      const res = await fetch(`/api/unsubscribe?token=${encodeURIComponent(token)}`, {
-        method: "POST",
-      });
+      const token =
+        new URLSearchParams(window.location.search).get("token") ?? "";
+      const res = await fetch(
+        `/api/unsubscribe?token=${encodeURIComponent(token)}`,
+        {
+          method: "POST",
+        },
+      );
       if (!res.ok) throw new Error(String(res.status));
       setDone(true);
     } catch {
@@ -91,8 +95,8 @@ export default function Unsubscribe({ status }: Props) {
 
         {failed && (
           <p className="mt-3 max-w-md font-figtree text-sm text-red-600">
-            That didn&apos;t go through. Try again, or reply to any of our emails and
-            we&apos;ll take you off the list.
+            That didn&apos;t go through. Try again, or reply to any of our
+            emails and we&apos;ll take you off the list.
           </p>
         )}
 

--- a/src/pages/unsubscribe.tsx
+++ b/src/pages/unsubscribe.tsx
@@ -1,18 +1,57 @@
 import type { GetServerSideProps } from "next";
+import { useState } from "react";
 import SEO from "~/components/seo";
-import { unsubscribeByToken } from "~/server/subscribers";
+import { tokenExists } from "~/server/subscribers";
 
-type Props = { status: "ok" | "invalid" };
+// This page used to call unsubscribeByToken() inside getServerSideProps, which
+// meant a plain GET unsubscribed the recipient. Link scanners fetch every URL in
+// an incoming email, so Microsoft Defender Safe Links silently unsubscribed people
+// who had not opened the message, let alone clicked anything.
+//
+// It was not theoretical. Of 497 unsubscribes on the HW13 announcement, 489
+// happened within two minutes of that recipient's own send — before a human could
+// plausibly have read the email. Eight were real.
+//
+// So: GET only looks the token up and renders a button. The write happens on POST
+// to /api/unsubscribe, which a scanner will not issue. The RFC 8058 one-click path
+// in that same handler already used POST and was never affected — Gmail and Apple
+// Mail's built-in Unsubscribe button keeps working with no extra click.
+
+type Props = { status: "ready" | "invalid" | "already" };
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const token = typeof ctx.query.token === "string" ? ctx.query.token : "";
   if (!token) return { props: { status: "invalid" } };
-  const matched = await unsubscribeByToken(token);
-  return { props: { status: matched ? "ok" : "invalid" } };
+
+  // Read-only. Nothing on this request path may write.
+  const state = await tokenExists(token);
+  return { props: { status: state } };
 };
 
 export default function Unsubscribe({ status }: Props) {
-  const ok = status === "ok";
+  const [done, setDone] = useState(status === "already");
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  async function confirm() {
+    setBusy(true);
+    setFailed(false);
+    try {
+      const token = new URLSearchParams(window.location.search).get("token") ?? "";
+      const res = await fetch(`/api/unsubscribe?token=${encodeURIComponent(token)}`, {
+        method: "POST",
+      });
+      if (!res.ok) throw new Error(String(res.status));
+      setDone(true);
+    } catch {
+      setFailed(true);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const invalid = status === "invalid";
+
   return (
     <>
       <SEO title="Unsubscribe" />
@@ -23,14 +62,40 @@ export default function Unsubscribe({ status }: Props) {
           alt="Hack Western"
           className="mb-8 w-full max-w-md rounded-lg"
         />
+
         <h1 className="font-cossetteTexte text-2xl font-bold text-heavy">
-          {ok ? "You've been unsubscribed" : "Invalid link"}
+          {invalid
+            ? "Invalid link"
+            : done
+              ? "You've been unsubscribed"
+              : "Unsubscribe from Hack Western emails?"}
         </h1>
+
         <p className="mt-3 max-w-md font-figtree text-medium">
-          {ok
-            ? "You won't receive further Hack Western update emails at this address."
-            : "This unsubscribe link is missing or invalid."}
+          {invalid
+            ? "This unsubscribe link is missing or invalid."
+            : done
+              ? "You won't receive further Hack Western update emails at this address."
+              : "You'll stop receiving Hack Western update emails at this address."}
         </p>
+
+        {!invalid && !done && (
+          <button
+            onClick={confirm}
+            disabled={busy}
+            className="mt-6 rounded-lg bg-primary px-5 py-2 font-figtree text-primary-foreground disabled:opacity-60"
+          >
+            {busy ? "Unsubscribing…" : "Confirm unsubscribe"}
+          </button>
+        )}
+
+        {failed && (
+          <p className="mt-3 max-w-md font-figtree text-sm text-red-600">
+            That didn&apos;t go through. Try again, or reply to any of our emails and
+            we&apos;ll take you off the list.
+          </p>
+        )}
+
         <a
           href="https://www.hackwestern.com"
           className="mt-6 rounded-lg bg-primary px-5 py-2 font-figtree text-primary-foreground"

--- a/src/server/api/routers/preregistration.test.ts
+++ b/src/server/api/routers/preregistration.test.ts
@@ -34,9 +34,14 @@ describe("preregistration.create", async () => {
   beforeEach(async () => {
     sendEmailSpy.mockClear();
 
+    // Delete by the NORMALIZED address, because that is what create() stores.
+    // Deleting by the raw seed address left the row behind, and every later test
+    // then failed on its own first create with a spurious CONFLICT.
     await db
       .delete(preregistrations)
-      .where(eq(preregistrations.email, testPreregistration.email));
+      .where(
+        eq(preregistrations.email, normalizeEmail(testPreregistration.email)),
+      );
   });
 
   afterEach(() => {
@@ -51,7 +56,11 @@ describe("preregistration.create", async () => {
     const { id, createdAt, unsubscribeToken, unsubscribedAt, ...got } = result;
     (void id, createdAt, unsubscribedAt);
 
-    expect(got).toEqual(want);
+    // The stored email is normalized, not the raw input. This assertion used to
+    // expect the raw form, which is exactly the bug it was hiding: storing
+    // "Ari_Maggio@gmail.com" while the duplicate check looked up the normalized
+    // form meant the same person could sign up twice and get every email twice.
+    expect(got).toEqual({ ...want, email: normalizeEmail(want.email) });
     // a unique unsubscribe token is generated for the updates email
     expect(unsubscribeToken).toMatch(/^[a-f0-9]{40}$/);
   });

--- a/src/server/api/routers/preregistration.ts
+++ b/src/server/api/routers/preregistration.ts
@@ -39,11 +39,18 @@ export const preregistrationRouter = createTRPCRouter({
           });
         }
 
+        // Normalize once and use it for BOTH lookups and the insert. An earlier
+        // version checked preregistrations against the raw input while storing the
+        // raw input too, so "Arjun.gr97@gmail.com" and "arjun.gr97@gmail.com" were
+        // different rows: the lookup missed, and the unique index is byte-exact so it
+        // did not fire either. The same person signed up twice and got two of every
+        // email. Gmail dot-stripping widens that further — "a.rjun.gr97@" is the same
+        // mailbox again.
         const normalized = normalizeEmail(input.email);
         const [existingPreregistration, existingSubscriber] = await Promise.all(
           [
             db.query.preregistrations.findFirst({
-              where: ({ email }, { eq }) => eq(email, input.email),
+              where: ({ email }, { eq }) => eq(email, normalized),
             }),
             db.query.emailSubscribers.findFirst({
               where: ({ email }, { eq }) => eq(email, normalized),
@@ -62,7 +69,8 @@ export const preregistrationRouter = createTRPCRouter({
         const unsubscribeToken = generateUnsubscribeToken();
         const createdPreregistration = await db
           .insert(preregistrations)
-          .values({ ...input, unsubscribeToken })
+          // Stored normalized, so the lookups above can ever match it.
+          .values({ ...input, email: normalized, unsubscribeToken })
           .returning();
 
         // Send confirmation email. Don't fail the signup if the email bounces —

--- a/src/server/subscribers.ts
+++ b/src/server/subscribers.ts
@@ -46,6 +46,29 @@ export function editionFromSource(source: string): string {
   return source.replace(/^hw/, "");
 }
 
+/** Read-only lookup for the unsubscribe confirmation page.
+ *
+ *  Exists so that page can render without writing. It used to call
+ *  unsubscribeByToken() from getServerSideProps, which turned every GET — including
+ *  the ones link scanners issue — into an unsubscribe. Nothing in here mutates. */
+export async function tokenExists(
+  token: string,
+): Promise<"ready" | "already" | "invalid"> {
+  const sub = await db.query.emailSubscribers.findFirst({
+    where: eq(emailSubscribers.unsubscribeToken, token),
+    columns: { id: true, unsubscribedAt: true },
+  });
+  if (sub) return sub.unsubscribedAt ? "already" : "ready";
+
+  const pre = await db.query.preregistrations.findFirst({
+    where: eq(preregistrations.unsubscribeToken, token),
+    columns: { id: true, unsubscribedAt: true },
+  });
+  if (pre) return pre.unsubscribedAt ? "already" : "ready";
+
+  return "invalid";
+}
+
 export async function unsubscribeByToken(token: string): Promise<boolean> {
   // The token belongs to exactly one list (email_subscriber or preregistration
   // — kept disjoint by email). Try the campaign list first, then the updates


### PR DESCRIPTION
…eg emails

The unsubscribe page called unsubscribeByToken() inside getServerSideProps, so a plain GET was a write. Link scanners fetch every URL in an incoming email, so Microsoft Defender unsubscribed people who never opened the message: of 497 unsubscribes on the HW13 announcement, 489 landed within two minutes of that recipient's own send. Eight were real.

GET now only looks the token up and renders a confirm button; the write happens on POST to /api/unsubscribe, which a scanner will not issue. The RFC 8058 one-click path in that handler already used POST and is unchanged, so Gmail and Apple Mail's built-in Unsubscribe still works with no extra click. Adds a read-only tokenExists() for the page.

Separately, preregistration.create computed a normalized email, used it only for the email_subscriber lookup, then inserted the raw input and checked preregistrations against the raw input too. So Arjun.gr97@gmail.com stored raw while the lookup asked for the normalized form: the check missed, the unique index is byte-exact so it did not fire, and the same person could sign up twice and receive two of every email. Gmail dot stripping widens that further.

The page test now asserts getServerSideProps never calls the write path, which is the regression guard for the first bug.

closes (Github Issue number)

# Quick Overview of Changes

- (added x component)
- (added y function to a service on our backend)

# Checklist

- [ ] If any frontend changes were made, include a screenshot/demo in the overview
- [ ] Checked all uses of changed component(s)/function(s)
- [ ] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [ ] Check that CI is passing.
- [ ] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@lucianlavric @JasmineGu2
