### PR TITLE
788 team 04 team join codes

### DIFF
--- a/drizzle/0014_team_join_codes.sql
+++ b/drizzle/0014_team_join_codes.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "team" ALTER COLUMN "id" SET DATA TYPE varchar(12);--> statement-breakpoint
+-- Added nullable first, then backfilled, so the migration survives a team
+-- table that already has rows (a bare ADD COLUMN NOT NULL would fail).
+ALTER TABLE "team" ADD COLUMN "joinCode" varchar(6);--> statement-breakpoint
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN SELECT id FROM "team" WHERE "joinCode" IS NULL LOOP
+    UPDATE "team" SET "joinCode" = (
+      SELECT string_agg(substr('ABCDEFGHJKLMNPQRSTUVWXYZ23456789', (floor(random() * 32))::int + 1, 1), '')
+      FROM generate_series(1, 6)
+    ) WHERE id = r.id;
+  END LOOP;
+END $$;--> statement-breakpoint
+ALTER TABLE "team" ALTER COLUMN "joinCode" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "team" ADD CONSTRAINT "team_joinCode_unique" UNIQUE("joinCode");

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2360 @@
+{
+  "id": "244d8048-ee6f-4350-9b9b-e9f60ba7835e",
+  "prevId": "f2d4b687-f5e3-4235-890b-1a6716114f76",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IN_PROGRESS'"
+        },
+        "avatar_colour": {
+          "name": "avatar_colour",
+          "type": "avatar_colour",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_face": {
+          "name": "avatar_face",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_left_hand": {
+          "name": "avatar_left_hand",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_right_hand": {
+          "name": "avatar_right_hand",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_hat": {
+          "name": "avatar_hat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_residence": {
+          "name": "country_of_residence",
+          "type": "country",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year_of_study": {
+          "name": "year_of_study",
+          "type": "year_of_study",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "major": {
+          "name": "major",
+          "type": "major",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shirt_size": {
+          "name": "shirt_size",
+          "type": "shirt_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_restrictions": {
+          "name": "dietary_restrictions",
+          "type": "dietary_restrictions",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_restrictions_other": {
+          "name": "dietary_restrictions_other",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_of_hackathons": {
+          "name": "num_of_hackathons",
+          "type": "num_of_hackathons",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question1": {
+          "name": "question1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question2": {
+          "name": "question2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question3": {
+          "name": "question3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_link": {
+          "name": "github_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedin_link": {
+          "name": "linkedin_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "devpost_link": {
+          "name": "devpost_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resume_link": {
+          "name": "resume_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_link": {
+          "name": "other_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agree_code_of_conduct": {
+          "name": "agree_code_of_conduct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_share_with_sponsors": {
+          "name": "agree_share_with_sponsors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_share_with_mlh": {
+          "name": "agree_share_with_mlh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_emails_from_mlh": {
+          "name": "agree_emails_from_mlh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_will_be_18": {
+          "name": "agree_will_be_18",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "underrep_group": {
+          "name": "underrep_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ethnicity": {
+          "name": "ethnicity",
+          "type": "race/ethnicity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sexual_orientation": {
+          "name": "sexual_orientation",
+          "type": "sexual_orientation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canvas_data": {
+          "name": "canvas_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"paths\":[],\"timestamp\":0,\"version\":\"\"}'::jsonb"
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_relationship": {
+          "name": "emergency_contact_relationship",
+          "type": "emergency_contact_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone_number": {
+          "name": "emergency_contact_phone_number",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transportation_method": {
+          "name": "transportation_method",
+          "type": "transportation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_user_id_user_id_fk": {
+          "name": "application_user_id_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.day_of_registration": {
+      "name": "day_of_registration",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signed_in_at": {
+          "name": "signed_in_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "day_of_registration_user_id_user_id_fk": {
+          "name": "day_of_registration_user_id_user_id_fk",
+          "tableFrom": "day_of_registration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_subscriber": {
+      "name": "email_subscriber",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_subscriber_email_unique": {
+          "name": "email_subscriber_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "email_subscriber_unsubscribe_token_unique": {
+          "name": "email_subscriber_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hacker_check_result": {
+      "name": "hacker_check_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_type": {
+          "name": "check_type",
+          "type": "hacker_check_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "checked_by_user_id": {
+          "name": "checked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manual_override": {
+          "name": "manual_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hacker_check_user_idx": {
+          "name": "hacker_check_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hacker_check_unique_idx": {
+          "name": "hacker_check_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hacker_check_result_user_id_user_id_fk": {
+          "name": "hacker_check_result_user_id_user_id_fk",
+          "tableFrom": "hacker_check_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hacker_check_result_checked_by_user_id_user_id_fk": {
+          "name": "hacker_check_result_checked_by_user_id_user_id_fk",
+          "tableFrom": "hacker_check_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "checked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judge": {
+      "name": "judge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "judge_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'organizer'"
+        },
+        "track": {
+          "name": "track",
+          "type": "track[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marks_count": {
+          "name": "marks_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "marks_sum": {
+          "name": "marks_sum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "marks_squared_sum": {
+          "name": "marks_squared_sum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_id_user_id_fk": {
+          "name": "judge_id_user_id_fk",
+          "tableFrom": "judge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judging_queue": {
+      "name": "judging_queue",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "seen_judges": {
+          "name": "seen_judges",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rounds_remaining": {
+          "name": "rounds_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "judging_queue_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "current_judge_id": {
+          "name": "current_judge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "judging_queue_priority_idx": {
+          "name": "judging_queue_priority_idx",
+          "columns": [
+            {
+              "expression": "rounds_remaining",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "enqueued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "judging_queue_current_judge_idx": {
+          "name": "judging_queue_current_judge_idx",
+          "columns": [
+            {
+              "expression": "current_judge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "judging_queue_team_id_team_id_fk": {
+          "name": "judging_queue_team_id_team_id_fk",
+          "tableFrom": "judging_queue",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judging_queue_current_judge_id_judge_id_fk": {
+          "name": "judging_queue_current_judge_id_judge_id_fk",
+          "tableFrom": "judging_queue",
+          "tableTo": "judge",
+          "columnsFrom": [
+            "current_judge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judging_skip": {
+      "name": "judging_skip",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_id": {
+          "name": "judge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judging_skip_team_id_team_id_fk": {
+          "name": "judging_skip_team_id_team_id_fk",
+          "tableFrom": "judging_skip",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judging_skip_judge_id_judge_id_fk": {
+          "name": "judging_skip_judge_id_judge_id_fk",
+          "tableFrom": "judging_skip",
+          "tableTo": "judge",
+          "columnsFrom": [
+            "judge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "judging_skip_team_id_judge_id_pk": {
+          "name": "judging_skip_team_id_judge_id_pk",
+          "columns": [
+            "team_id",
+            "judge_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preregistration": {
+      "name": "preregistration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "preregistration_email_unique": {
+          "name": "preregistration_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "preregistration_unsubscribe_token_unique": {
+          "name": "preregistration_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reset_password_token": {
+      "name": "reset_password_token",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reset_password_token_userId_user_id_fk": {
+          "name": "reset_password_token_userId_user_id_fk",
+          "tableFrom": "reset_password_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_user_id": {
+          "name": "applicant_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "originality_rating": {
+          "name": "originality_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "technicality_rating": {
+          "name": "technicality_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "passion_rating": {
+          "name": "passion_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "referral": {
+          "name": "referral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "applicant_user_id_idx": {
+          "name": "applicant_user_id_idx",
+          "columns": [
+            {
+              "expression": "applicant_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reviewer_user_id_user_id_fk": {
+          "name": "review_reviewer_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_applicant_user_id_application_user_id_fk": {
+          "name": "review_applicant_user_id_application_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicant_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_applicant_user_id_user_id_fk": {
+          "name": "review_applicant_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "applicant_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_reviewer_user_id_applicant_user_id_pk": {
+          "name": "review_reviewer_user_id_applicant_user_id_pk",
+          "columns": [
+            "reviewer_user_id",
+            "applicant_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_item": {
+      "name": "scavenger_hunt_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scavenger_hunt_item_code_unique": {
+          "name": "scavenger_hunt_item_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_redemption": {
+      "name": "scavenger_hunt_redemption",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "redemption_user_idx": {
+          "name": "redemption_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scavenger_hunt_redemption_user_id_user_id_fk": {
+          "name": "scavenger_hunt_redemption_user_id_user_id_fk",
+          "tableFrom": "scavenger_hunt_redemption",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scavenger_hunt_redemption_reward_id_scavenger_hunt_reward_id_fk": {
+          "name": "scavenger_hunt_redemption_reward_id_scavenger_hunt_reward_id_fk",
+          "tableFrom": "scavenger_hunt_redemption",
+          "tableTo": "scavenger_hunt_reward",
+          "columnsFrom": [
+            "reward_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_reward": {
+      "name": "scavenger_hunt_reward",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_points": {
+          "name": "cost_points",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_scan": {
+      "name": "scavenger_hunt_scan",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanner_id": {
+          "name": "scanner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scan_user_idx": {
+          "name": "scan_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scan_scanner_idx": {
+          "name": "scan_scanner_idx",
+          "columns": [
+            {
+              "expression": "scanner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scavenger_hunt_scan_user_id_user_id_fk": {
+          "name": "scavenger_hunt_scan_user_id_user_id_fk",
+          "tableFrom": "scavenger_hunt_scan",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scavenger_hunt_scan_scanner_id_user_id_fk": {
+          "name": "scavenger_hunt_scan_scanner_id_user_id_fk",
+          "tableFrom": "scavenger_hunt_scan",
+          "tableTo": "user",
+          "columnsFrom": [
+            "scanner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scavenger_hunt_scan_item_id_scavenger_hunt_item_id_fk": {
+          "name": "scavenger_hunt_scan_item_id_scavenger_hunt_item_id_fk",
+          "tableFrom": "scavenger_hunt_scan",
+          "tableTo": "scavenger_hunt_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scavenger_hunt_scan_user_id_item_id_pk": {
+          "name": "scavenger_hunt_scan_user_id_item_id_pk",
+          "columns": [
+            "user_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_check_result": {
+      "name": "team_check_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_type": {
+          "name": "check_type",
+          "type": "team_check_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "checked_by_user_id": {
+          "name": "checked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manual_override": {
+          "name": "manual_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_check_team_idx": {
+          "name": "team_check_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_check_unique_idx": {
+          "name": "team_check_unique_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_check_result_team_id_team_id_fk": {
+          "name": "team_check_result_team_id_team_id_fk",
+          "tableFrom": "team_check_result",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_check_result_checked_by_user_id_user_id_fk": {
+          "name": "team_check_result_checked_by_user_id_user_id_fk",
+          "tableFrom": "team_check_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "checked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_mark": {
+      "name": "team_mark",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_id": {
+          "name": "judge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_type": {
+          "name": "round_type",
+          "type": "round_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_mark_team_idx": {
+          "name": "team_mark_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_mark_judge_idx": {
+          "name": "team_mark_judge_idx",
+          "columns": [
+            {
+              "expression": "judge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_mark_team_id_team_id_fk": {
+          "name": "team_mark_team_id_team_id_fk",
+          "tableFrom": "team_mark",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_mark_judge_id_judge_id_fk": {
+          "name": "team_mark_judge_id_judge_id_fk",
+          "tableFrom": "team_mark",
+          "tableTo": "judge",
+          "columnsFrom": [
+            "judge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "devpost_url": {
+          "name": "devpost_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_status": {
+          "name": "submission_status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "track[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_github_usernames": {
+          "name": "member_github_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_devpost_usernames": {
+          "name": "member_devpost_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "joinCode": {
+          "name": "joinCode",
+          "type": "varchar(6)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_created_at_idx": {
+          "name": "team_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_joinCode_unique": {
+          "name": "team_joinCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "joinCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hacker'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scavenger_hunt_earned": {
+          "name": "scavenger_hunt_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "scavenger_hunt_balance": {
+          "name": "scavenger_hunt_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "user_scavenger_hunt_earned_idx": {
+          "name": "user_scavenger_hunt_earned_idx",
+          "columns": [
+            {
+              "expression": "scavenger_hunt_earned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_scavenger_hunt_balance_idx": {
+          "name": "user_scavenger_hunt_balance_idx",
+          "columns": [
+            {
+              "expression": "scavenger_hunt_balance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_team_id_idx": {
+          "name": "user_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_team_id_team_id_fk": {
+          "name": "user_team_id_team_id_fk",
+          "tableFrom": "user",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_token": {
+      "name": "verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_token_identifier_token_pk": {
+          "name": "verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "IN_PROGRESS",
+        "PENDING_REVIEW",
+        "IN_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED",
+        "DECLINED",
+        "CONFIRMED"
+      ]
+    },
+    "public.avatar_colour": {
+      "name": "avatar_colour",
+      "schema": "public",
+      "values": [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple",
+        "pink"
+      ]
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "public",
+      "values": [
+        "Canada",
+        "United States",
+        "India",
+        "Other"
+      ]
+    },
+    "public.dietary_restrictions": {
+      "name": "dietary_restrictions",
+      "schema": "public",
+      "values": [
+        "Vegetarian",
+        "Vegan",
+        "Kosher",
+        "Halal",
+        "Other"
+      ]
+    },
+    "public.emergency_contact_relationship": {
+      "name": "emergency_contact_relationship",
+      "schema": "public",
+      "values": [
+        "Parent",
+        "Sibling",
+        "Other family member",
+        "Friend",
+        "Coworker",
+        "Other"
+      ]
+    },
+    "public.race/ethnicity": {
+      "name": "race/ethnicity",
+      "schema": "public",
+      "values": [
+        "American Indian or Alaskan Native",
+        "Asian / Pacific Islander",
+        "Black or African American",
+        "Hispanic",
+        "White / Caucasian",
+        "Multiple ethnicity / Other",
+        "Prefer not to answer"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "Female",
+        "Male",
+        "Non-Binary",
+        "Other",
+        "Prefer not to answer"
+      ]
+    },
+    "public.hacker_check_type": {
+      "name": "hacker_check_type",
+      "schema": "public",
+      "values": [
+        "IS_OF_AGE",
+        "IS_REGISTERED"
+      ]
+    },
+    "public.judge_type": {
+      "name": "judge_type",
+      "schema": "public",
+      "values": [
+        "organizer",
+        "sponsored"
+      ]
+    },
+    "public.judging_queue_status": {
+      "name": "judging_queue_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "assigned"
+      ]
+    },
+    "public.major": {
+      "name": "major",
+      "schema": "public",
+      "values": [
+        "Computer Science",
+        "Computer Engineering",
+        "Software Engineering",
+        "Other Engineering Discipline",
+        "Information Systems",
+        "Information Technology",
+        "System Administration",
+        "Natural Sciences (Biology, Chemistry, Physics, etc.)",
+        "Mathematics/Statistics",
+        "Web Development/Web Design",
+        "Business Administration",
+        "Humanities",
+        "Social Science",
+        "Fine Arts/Performing Arts",
+        "Other"
+      ]
+    },
+    "public.num_of_hackathons": {
+      "name": "num_of_hackathons",
+      "schema": "public",
+      "values": [
+        "0",
+        "1-3",
+        "4-6",
+        "7+"
+      ]
+    },
+    "public.round_type": {
+      "name": "round_type",
+      "schema": "public",
+      "values": [
+        "regular",
+        "sponsored"
+      ]
+    },
+    "public.sexual_orientation": {
+      "name": "sexual_orientation",
+      "schema": "public",
+      "values": [
+        "Asexual / Aromantic",
+        "Pansexual, Demisexual or Omnisexual",
+        "Bisexual",
+        "Queer",
+        "Gay / Lesbian",
+        "Heterosexual / Straight",
+        "Other",
+        "Prefer not to answer"
+      ]
+    },
+    "public.shirt_size": {
+      "name": "shirt_size",
+      "schema": "public",
+      "values": [
+        "S",
+        "M",
+        "L",
+        "XL"
+      ]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "late"
+      ]
+    },
+    "public.team_check_type": {
+      "name": "team_check_type",
+      "schema": "public",
+      "values": [
+        "COMMIT_WITHIN_ALLOTTED_TIME",
+        "ONLY_TEAM_MEMBER_COMMITS",
+        "DEVPOST_MEMBERS_REGISTERED"
+      ]
+    },
+    "public.track": {
+      "name": "track",
+      "schema": "public",
+      "values": [
+        "Best Use of Cohere",
+        "Best Use of AntiGravity",
+        "Best Domain",
+        "General"
+      ]
+    },
+    "public.transportation_method": {
+      "name": "transportation_method",
+      "schema": "public",
+      "values": [
+        "Waterloo",
+        "Toronto",
+        "Hamilton",
+        "None"
+      ]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": [
+        "hacker",
+        "organizer",
+        "sponsor"
+      ]
+    },
+    "public.year_of_study": {
+      "name": "year_of_study",
+      "schema": "public",
+      "values": [
+        "1st",
+        "2nd",
+        "3rd",
+        "4th",
+        "5th+",
+        "N/A",
+        "Prefer not to answer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1788080333798,
       "tag": "0013_apply_judging_triggers",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1788080707170,
+      "tag": "0014_team_join_codes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/api/routers/cheat-check.test.ts
+++ b/src/server/api/routers/cheat-check.test.ts
@@ -378,6 +378,7 @@ describe.skipIf(!process.env.GITHUB_TOKEN)(
         githubUrl: HACKWESTERN_GITHUB_URL,
         devpostUrl: "https://devpost.com/software/placeholder",
         memberGithubUsernames: ["john_doe"],
+        joinCode: "0000",
       });
     });
 

--- a/src/server/api/routers/judging.test.ts
+++ b/src/server/api/routers/judging.test.ts
@@ -63,7 +63,8 @@ async function makeTeam(opts?: {
   tracks?: Track[];
   submissionStatus?: SubmissionStatus;
 }) {
-  const id = faker.string.alphanumeric(6);
+  const code = faker.string.alphanumeric(4);
+  const id = faker.string.alphanumeric(12);
   await db.insert(teams).values({
     id,
     name: `team-${id}`,
@@ -71,6 +72,7 @@ async function makeTeam(opts?: {
     githubUrl: `https://github.com/${id}`,
     tracks: opts?.tracks,
     submissionStatus: opts?.submissionStatus ?? "submitted",
+    joinCode: code,
   });
   return id;
 }

--- a/src/server/api/routers/teams.test.ts
+++ b/src/server/api/routers/teams.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, test, beforeAll, afterAll, assert } from "vitest";
+import {
+  describe,
+  expect,
+  test,
+  beforeAll,
+  afterAll,
+  assert,
+  beforeEach,
+  afterEach,
+} from "vitest";
 import { mockSession } from "~/server/auth";
 import { db } from "~/server/db";
 import { createInnerTRPCContext } from "../trpc";
@@ -13,9 +22,13 @@ const ctx = createInnerTRPCContext({ session });
 const caller = createCaller(ctx);
 
 const insertTeam = async () => {
-  const id = faker.string.sample(6);
-  await db.insert(teams).values({ name: "Team 1", id: id });
-  return id;
+  const joinCode = faker.string.fromCharacters(
+    "ABCDEFGHJKLMNPQRSTUVWXYZ23456789",
+    6,
+  );
+  const id = faker.string.sample(12);
+  await db.insert(teams).values({ name: "Team 1", id: id, joinCode: joinCode });
+  return { code: joinCode, id: id };
 };
 const removeTeam = async (id: string) => {
   await db.delete(teams).where(eq(teams.id, id));
@@ -38,7 +51,7 @@ describe("teams basic endpoints", () => {
       const teamId = await insertTeam();
       await db
         .update(users)
-        .set({ teamId: teamId })
+        .set({ teamId: teamId.id })
         .where(eq(users.id, ctx.session!.user.id));
       const res = caller.teams.createTeam({ name: "Best Team" });
 
@@ -48,28 +61,31 @@ describe("teams basic endpoints", () => {
         .update(users)
         .set({ teamId: null })
         .where(eq(users.id, ctx.session!.user.id));
-      await removeTeam(teamId);
+      await removeTeam(teamId.id);
     });
   });
   describe.sequential("joinTeam Tests", () => {
-    let teamId: string;
-    beforeAll(async () => {
+    let teamId: { code: string; id: string };
+    beforeEach(async () => {
       teamId = await insertTeam();
     });
-    afterAll(async () => {
-      await removeTeam(teamId);
+    afterEach(async () => {
+      await removeTeam(teamId.id);
     });
     test("joinTeam success", async () => {
-      const res = caller.teams.joinTeam({ teamId: teamId });
+      const res = caller.teams.joinTeam({ joinCode: teamId.code });
 
       return expect(res).resolves.toEqual({ success: true });
     });
-    test("joinTeam fail", async () => {
-      const res = caller.teams.joinTeam({ teamId: teamId });
+    test("joinTeam fail because already in team", async () => {
+      const res_suc = caller.teams.joinTeam({ joinCode: teamId.code });
+      await expect(res_suc).resolves.toEqual({ success: true });
+
+      const res = caller.teams.joinTeam({ joinCode: teamId.code });
 
       return expect(res).rejects.toThrow();
     });
-    test("joinTeam full", async () => {
+    test("joinTeam fail because team is full", async () => {
       const teamId = await insertTeam();
 
       const s = () => {
@@ -79,14 +95,14 @@ describe("teams basic endpoints", () => {
           email: faker.internet.email(),
           emailVerified: faker.date.anytime(),
           image: faker.image.avatar(),
-          teamId: teamId,
+          teamId: teamId.id,
         };
       };
       const newUsers = Array.from({ length: 4 }, s);
 
       await db.insert(users).values(newUsers);
 
-      const res = caller.teams.joinTeam({ teamId: teamId });
+      const res = caller.teams.joinTeam({ joinCode: teamId.code });
       await expect(res).rejects.toThrow();
 
       await db.delete(users).where(
@@ -95,11 +111,11 @@ describe("teams basic endpoints", () => {
           newUsers.map((u) => u.id),
         ),
       );
-      await removeTeam(teamId);
+      await removeTeam(teamId.id);
     });
   });
   describe.sequential("leaveTeam Tests", () => {
-    let teamId: string;
+    let teamId: { code: string; id: string };
     beforeAll(async () => {
       teamId = await insertTeam();
     });
@@ -107,45 +123,45 @@ describe("teams basic endpoints", () => {
     test("leaveTeam success", async () => {
       await db
         .update(users)
-        .set({ teamId: teamId })
+        .set({ teamId: teamId.id })
         .where(eq(users.id, ctx.session!.user.id));
       const res = caller.teams.leaveTeam();
 
       await expect(res).resolves.toEqual({ success: true });
       const deletedTeam = await db.query.teams.findFirst({
-        where: eq(teams.id, teamId),
+        where: eq(teams.id, teamId.id),
       });
       expect(deletedTeam).toBeUndefined();
     });
-    test("leaveTeam fail", async () => {
+    test("leaveTeam fail because not in team", async () => {
       const res = caller.teams.leaveTeam();
 
       await expect(res).rejects.toThrow();
     });
   });
   describe.sequential("deleteTeam Tests", () => {
-    let teamId: string;
+    let teamId: { code: string; id: string };
     beforeAll(async () => {
       teamId = await insertTeam();
     });
     afterAll(async () => {
-      await removeTeam(teamId);
+      await removeTeam(teamId.id);
     });
 
     test("deleteTeam success", async () => {
       await db
         .update(users)
-        .set({ teamId: teamId })
+        .set({ teamId: teamId.id })
         .where(eq(users.id, ctx.session!.user.id));
 
       const res = caller.teams.deleteTeam();
       await expect(res).resolves.toEqual({ success: true });
 
       expect(
-        await db.query.teams.findFirst({ where: eq(teams.id, teamId) }),
+        await db.query.teams.findFirst({ where: eq(teams.id, teamId.id) }),
       ).toBeUndefined();
     });
-    test("deleteTeam fail", async () => {
+    test("deleteTeam fail because not in team", async () => {
       const res = caller.teams.deleteTeam();
       await expect(res).rejects.toThrow();
     });
@@ -153,16 +169,16 @@ describe("teams basic endpoints", () => {
   describe.sequential("submitProject Tests", () => {
     test("submitProject fails with no project saved", async () => {
       const teamId = await insertTeam();
-      const join = caller.teams.joinTeam({ teamId: teamId });
+      const join = caller.teams.joinTeam({ joinCode: teamId.code });
       await expect(join).resolves.toEqual({ success: true });
 
       const res = caller.teams.submitProject();
       await expect(res).rejects.toThrow();
-      await removeTeam(teamId);
+      await removeTeam(teamId.id);
     });
     test("submitProject success", async () => {
       const teamId = await insertTeam();
-      const join = caller.teams.joinTeam({ teamId: teamId });
+      const join = caller.teams.joinTeam({ joinCode: teamId.code });
       await expect(join).resolves.toEqual({ success: true });
 
       const save = await caller.teams.saveProject({
@@ -182,11 +198,11 @@ describe("teams basic endpoints", () => {
 
       const submit = caller.teams.submitProject();
       await expect(submit).resolves.toEqual({ success: true });
-      await removeTeam(teamId);
+      await removeTeam(teamId.id);
     });
     test("submitProject fails when member usernames missing", async () => {
       const teamId = await insertTeam();
-      const join = caller.teams.joinTeam({ teamId: teamId });
+      const join = caller.teams.joinTeam({ joinCode: teamId.code });
       await expect(join).resolves.toEqual({ success: true });
 
       const save = caller.teams.saveProject({
@@ -198,13 +214,13 @@ describe("teams basic endpoints", () => {
 
       const submit = caller.teams.submitProject();
       await expect(submit).rejects.toThrow();
-      await removeTeam(teamId);
+      await removeTeam(teamId.id);
     });
   });
   describe("saveProject Tests", () => {
     test("saveProject", async () => {
       const teamId = await insertTeam();
-      const join = caller.teams.joinTeam({ teamId: teamId });
+      const join = caller.teams.joinTeam({ joinCode: teamId.code });
       await expect(join).resolves.toEqual({ success: true });
 
       const res = caller.teams.saveProject({ devpostUrl: "Url" });
@@ -214,13 +230,42 @@ describe("teams basic endpoints", () => {
       await expect(res1).resolves.toEqual({ success: true });
 
       const team = await db.query.teams.findFirst({
-        where: eq(teams.id, teamId),
+        where: eq(teams.id, teamId.id),
       });
 
       const tracks = (team?.tracks ?? [""])[0];
 
       assert(team?.devpostUrl == "Url");
       assert(tracks == "General");
+
+      return removeTeam(teamId.id);
+    });
+  });
+  describe.sequential("getTeam Tests", () => {
+    test("getTeam success", async () => {
+      const teamId = await insertTeam();
+
+      const join = caller.teams.joinTeam({ joinCode: teamId.code });
+
+      await expect(join).resolves.toEqual({ success: true });
+
+      const get = caller.teams.getTeam();
+
+      await expect(get).resolves.toEqual({
+        name: "Team 1",
+        devpostUrl: null,
+        githubUrl: null,
+        tracks: null,
+        memberGithubUsernames: null,
+        memberDevpostUsernames: null,
+        joinCode: teamId.code,
+      });
+      return removeTeam(teamId.id);
+    });
+    test("getTeam fail because not in team", async () => {
+      const get = caller.teams.getTeam();
+
+      await expect(get).rejects.toThrow();
     });
   });
 });

--- a/src/server/api/routers/teams.ts
+++ b/src/server/api/routers/teams.ts
@@ -5,8 +5,9 @@ import { db } from "~/server/db";
 import { teams, trackEnum, users } from "~/server/db/schema";
 import { count, eq } from "drizzle-orm";
 import { randomBytes } from "crypto";
-import { createInsertSchema } from "drizzle-zod";
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { env } from "~/env";
+import { customAlphabet } from "nanoid";
 
 const teamsSaveSchema = createInsertSchema(teams, {
   name: z.string().optional(),
@@ -14,6 +15,14 @@ const teamsSaveSchema = createInsertSchema(teams, {
   memberGithubUsernames: z.array(z.string()),
   tracks: z.array(z.enum(trackEnum.enumValues)),
 }).omit({
+  joinCode: true,
+  id: true,
+  submissionStatus: true,
+  submittedAt: true,
+  createdAt: true,
+});
+
+const teamsSelectSchema = createSelectSchema(teams).omit({
   id: true,
   submissionStatus: true,
   submittedAt: true,
@@ -49,6 +58,38 @@ const assertValidTeam = async (ctx: { session: { user: { id: string } } }) => {
   return currentTeam.teamId;
 };
 export const teamsRouter = createTRPCRouter({
+  getTeam: protectedProcedure.query(async ({ ctx }) => {
+    const teamId = await db.query.users.findFirst({
+      columns: { teamId: true },
+      where: eq(users.id, ctx.session.user.id),
+    });
+    if (!teamId) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "User not found",
+      });
+    }
+    if (teamId.teamId == null) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "This user is not part of a team",
+      });
+    }
+
+    const team = await db.query.teams.findFirst({
+      where: eq(teams.id, teamId.teamId),
+    });
+    if (!team) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Team does not exist",
+      });
+    }
+
+    const zodSchema = teamsSelectSchema.parse(team);
+
+    return { ...zodSchema };
+  }),
   createTeam: protectedProcedure
     .input(z.object({ name: z.string() }))
     .mutation(async ({ ctx, input }) => {
@@ -76,13 +117,27 @@ export const teamsRouter = createTRPCRouter({
         });
       }
 
-      const id = randomBytes(3).toString("hex");
+      // 6 chars over a 32-symbol alphabet (~30 bits): guessing a valid code is
+      // impractical without rate limiting, which joinTeam doesn't have.
+      const genCode = customAlphabet("ABCDEFGHJKLMNPQRSTUVWXYZ23456789", 6);
 
+      let id = randomBytes(6).toString("hex");
       await db.transaction(async (tx) => {
-        await tx.insert(teams).values({
-          id: id,
-          name: input.name,
-        });
+        let rows = [];
+        while (rows.length == 0) {
+          id = randomBytes(6).toString("hex");
+
+          const joinCode = genCode();
+          rows = await tx
+            .insert(teams)
+            .values({
+              id: id,
+              name: input.name,
+              joinCode: joinCode,
+            })
+            .onConflictDoNothing()
+            .returning();
+        }
         await tx
           .update(users)
           .set({ teamId: id })
@@ -94,7 +149,15 @@ export const teamsRouter = createTRPCRouter({
       };
     }),
   joinTeam: protectedProcedure
-    .input(z.object({ teamId: z.string() }))
+    .input(
+      z.object({
+        joinCode: z
+          .string()
+          .trim()
+          .length(6)
+          .transform((s) => s.toUpperCase()),
+      }),
+    )
     .mutation(async ({ ctx, input }) => {
       const currentTeam = await db.query.users.findFirst({
         columns: { teamId: true },
@@ -113,37 +176,44 @@ export const teamsRouter = createTRPCRouter({
             "This user it already a part of a team, leave their current team to join a new one",
         });
       }
-      if (!input.teamId) {
+      if (!input.joinCode) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "No specified teamId",
+          message: "No specified joinCode",
         });
       }
-      const team = await db.query.teams.findFirst({
-        where: eq(teams.id, input.teamId),
-      });
-      if (!team) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Team does not exist",
-        });
-      }
-      const [teamSize] = await db
-        .select({ value: count() })
-        .from(users)
-        .where(eq(users.teamId, input.teamId));
-      const size = teamSize?.value ?? 100;
+      await db.transaction(async (tx) => {
+        const [team] = await tx
+          .select({ id: teams.id })
+          .from(teams)
+          .where(eq(teams.joinCode, input.joinCode))
+          .for("update");
 
-      if (size >= 4) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Team is full (max 4)",
-        });
-      }
-      await db
-        .update(users)
-        .set({ teamId: input.teamId })
-        .where(eq(users.id, ctx.session.user.id));
+        if (!team) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Team does not exist",
+          });
+        }
+        const teamId = team.id;
+
+        const [teamSize] = await tx
+          .select({ value: count() })
+          .from(users)
+          .where(eq(users.teamId, teamId));
+        const size = teamSize?.value ?? 100;
+
+        if (size >= 4) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Team is full (max 4)",
+          });
+        }
+        await tx
+          .update(users)
+          .set({ teamId: teamId })
+          .where(eq(users.id, ctx.session.user.id));
+      });
 
       return { success: true };
     }),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -215,7 +215,7 @@ export const teamCheckType = pgEnum("team_check_type", [
 export const teams = pgTable(
   "team",
   {
-    id: varchar("id", { length: 6 }).notNull().primaryKey(),
+    id: varchar("id", { length: 12 }).notNull().primaryKey(),
     name: varchar("name", { length: 255 }).notNull(),
 
     // Project submission
@@ -232,6 +232,7 @@ export const teams = pgTable(
     createdAt: timestamp("created_at", { mode: "date", precision: 3 })
       .defaultNow()
       .notNull(),
+    joinCode: varchar("joinCode", { length: 6 }).notNull().unique(),
   },
   (t) => [index("team_created_at_idx").on(t.createdAt)],
 );


### PR DESCRIPTION
Continuation of #823, closed as a side effect of a `dev` history rewrite (same platform limitation as #852/#853 — GitHub blocks reopening a PR once its branch was force-pushed while closed).

Renumbered its two migrations to avoid colliding with what's landed on `dev` since: 0011→0012 (`puzzling_exiles`) and 0012→0013 (`luxuriant_midnight`), chained correctly. Same for the later `black_young_avengers` migration (0013→0014). No content changes — same 7 commits, `tsc` + full test suite (246 passed) verified green after the rebuild.

Original description carries over unchanged below.

---

closes (Github Issue number)

# Quick Overview of Changes

- added joinCode to db schema (joinCodes are fixed and set at team creation
- modified joinTeam to take joinCode as input
- added getTeam route
- modified tests to fit new

# Checklist

- [ ] If any frontend changes were made, include a screenshot/demo in the overview
- [ ] Checked all uses of changed component(s)/function(s)
- [x] If any changes were made to our backend services, at least one (happy path) unit test was added OR a `TODO` comment was added to create one.
- [x] Check that CI is passing.
- [ ] If no (re-)reviews after 1-2 days, ping the web leads on the discord to remind them to review the PR.

@lucianlavric @JasmineGu2