### PR TITLE
[SUPERSEDED, DO NOT MERGE] feat(email): full Mailjet transport, held cutover from Cloudflare

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,19 +35,15 @@ GOOGLE_CLIENT_SECRET=""
 DISCORD_CLIENT_ID=""
 DISCORD_CLIENT_SECRET=""
 
-# Mailjet — the only email transport, Send API v3.1. Drip sends from
-# mail.hackwestern.com, transactional (signup/verify/reset/application) sends
-# from the apex hackwestern.com.
+# Mailjet — email transport (Send API v3.1). Required at runtime to send.
+# Use the transactional subaccount's API key + secret.
 MAILJET_API_KEY=""
 MAILJET_SECRET_KEY=""
 
-# Mailjet Event API webhook auth (src/pages/api/mailjet-webhook.ts). Mailjet
-# doesn't sign payloads, so these ride in the registered webhook URL's userinfo
-# and are checked as HTTP Basic auth. Keep them alphanumeric — percent-encoded
-# userinfo round-trips inconsistently. Register with
-# `npx tsx scripts/register-mailjet-webhook.ts --apply`.
-MAILJET_WEBHOOK_USER=""
-MAILJET_WEBHOOK_PASSWORD=""
+# Cloudflare Email Service — now only used by scripts/sync-cf-suppression.ts
+# (the send transport moved to Mailjet). Retire once suppression sync is ported.
+CLOUDFLARE_EMAIL_API_TOKEN=""
+CLOUDFLARE_ACCOUNT_ID=""
 
 # Kickbox email verification (optional). Set to enable the paid signup-email
 # verification layer; leave blank to run free validation only.

--- a/.github/workflows/send-campaign.yml
+++ b/.github/workflows/send-campaign.yml
@@ -55,8 +55,8 @@ jobs:
     environment: Production
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      # Drip sends via Mailjet (scripts/send-campaign.ts). Transactional email
-      # stays on Cloudflare, so this workflow needs only the Mailjet creds.
+      # Email transport is Mailjet (src/server/mail.ts). Set these secrets before
+      # merging the Mailjet cutover; until then the drip logs a send error.
       MAILJET_API_KEY: ${{ secrets.MAILJET_API_KEY }}
       MAILJET_SECRET_KEY: ${{ secrets.MAILJET_SECRET_KEY }}
       SKIP_ENV_VALIDATION: "1"

--- a/docs/email-mailjet-migration.md
+++ b/docs/email-mailjet-migration.md
@@ -1,0 +1,104 @@
+# Email migration: Cloudflare → Mailjet
+
+Full cutover of the email transport from **Cloudflare Email Sending** (beta,
+$5/mo, hard **200/day** cap) to **Mailjet Send API v3.1**. Cloudflare's 200/day
+cap can't do app-season bursts (a 4,000-person blast would take 20 days; ~1,600
+acceptance emails, 8 days), which is what forces the move — independent of cost.
+
+This branch is a **held replacement**: merge it the day Mailjet is provisioned
+and warmed. It is **not** a coexistence/feature-flag setup — on merge, all email
+(transactional + drip) sends via Mailjet.
+
+## What this branch changes (code — done)
+
+- `src/server/mail.ts` — transport swapped to Mailjet; **same `sendEmail`
+  interface**, so no caller changed (signup/verify/reset/application
+  confirmations + the drip all keep working).
+- `src/server/mail-mailjet.ts` — the Mailjet Send API v3.1 transport (pure,
+  unit-tested in `mail-mailjet.test.ts`).
+- `src/env.js` / `.env.example` — added `MAILJET_API_KEY`, `MAILJET_SECRET_KEY`
+  (optional at build time so the branch compiles before the account exists;
+  `sendEmail` guards on them at runtime).
+- `.github/workflows/send-campaign.yml` — drip now needs the Mailjet secrets.
+
+## Architecture: keep the two streams isolated
+
+Even on one platform, transactional and marketing must NOT share a sending
+reputation — a marketing-complaint spike cannot be allowed to sink
+password-reset / acceptance delivery. Isolate via:
+
+| Stream                                                          | Sender                         | Mailjet subaccount | Sending subdomain           |
+| --------------------------------------------------------------- | ------------------------------ | ------------------ | --------------------------- |
+| Transactional (signup/verify/reset, **acceptances/rejections**) | `hello@hackwestern.com`        | subaccount A       | e.g. `send.hackwestern.com` |
+| Marketing (drip, apps-open blast, 2-day warning)                | `updates@mail.hackwestern.com` | subaccount B       | `mail.hackwestern.com`      |
+
+Subaccount count is tier-gated (Starter = 1) — you likely need **Essential/
+Premium** for two. Each subaccount has its own API key/secret. This branch wires
+a single `MAILJET_API_KEY`/`MAILJET_SECRET_KEY`; when the second subaccount
+exists, route marketing sends (the drip) through its key — small follow-up in
+`sendEmail` (add an optional `stream` arg) or a second env pair.
+
+## Volume sizing
+
+Busiest month (October, high end): 4,000 apps-open + ~400 new-signup
+confirmations + ~1,600 application confirmations + ~1,600 decisions + 4,000
+2-day warning ≈ **~12,000** of the 15k Essential tier. Transactional +
+marketing share the monthly pool. Flex to the 20k tier for a spike month, then
+drop back.
+
+## Before merging (prerequisites — needs the live account)
+
+1. Mailjet account provisioned; plan chosen (Essential+ for 2 subaccounts).
+2. Two subaccounts created (transactional, marketing).
+3. Sending subdomains added + **SPF/DKIM verified** in Mailjet for each:
+   - SPF: add Mailjet's `include:spf.mailjet.com` to the subdomain's TXT.
+   - DKIM: add the `mailjet._domainkey.<subdomain>` TXT Mailjet generates.
+   - Keep DMARC (`p=reject` on the marketing subdomain is fine once aligned).
+   - Set a **custom tracking (CNAME) domain** so click-tracking is on
+     `hackwestern.com`, not Mailjet's shared `mjt.lu`.
+4. Secrets set in GitHub + Vercel: `MAILJET_API_KEY`, `MAILJET_SECRET_KEY`.
+5. **Warm up** (see below) — do NOT switch cold in-season.
+
+## Warmup (must land before October)
+
+Mailjet's IPs/your subdomains start cold. Start ~2 months out (by early
+September). Warm each stream to its own subdomain, engaged recipients first,
+daily and consistent:
+
+| Week | ~emails/day |
+| ---- | ----------- |
+| 1    | 20 → 40     |
+| 2    | 80          |
+| 3    | 120         |
+| 4    | 150+ (full) |
+
+Transactional warms naturally via real signups; front-load engaged seeds if
+needed. Watch bounces (<2%) and complaints (<0.10%) before each step up.
+
+## Cutover (merge day)
+
+1. Confirm prerequisites 1–5 above, warmup green.
+2. Merge this branch to `dev`, then promote `dev → main` (prod).
+3. Verify a live transactional send (trigger a signup) lands in inbox and
+   authenticates (SPF/DKIM/DMARC pass in "show original").
+4. Verify a drip run sends via Mailjet (`ok` lines, no send-config error).
+
+## Rollback
+
+Revert the merge commit (restores the Cloudflare transport in `mail.ts`); the
+Cloudflare secrets are still present, so transactional resumes immediately.
+Keep the Cloudflare account active until Mailjet is proven for a full cycle.
+
+## Phase 2 (after cutover is stable)
+
+- **Bounce handling:** Mailjet does NOT return permanent bounces synchronously
+  (Cloudflare did, via `permanent_bounces`). The drip's `classifyResult` →
+  `bouncedAt` marking goes quiet. Port `scripts/sync-cf-suppression.ts` to
+  Mailjet's suppression/contact-events API so bounced addresses are marked in
+  the DB. Mailjet auto-suppresses known-bad addresses regardless, so no mail is
+  sent to them in the meantime.
+- **Retire Cloudflare:** once suppression sync is ported, remove
+  `CLOUDFLARE_EMAIL_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` from `src/env.js`,
+  `.env.example`, and the workflows; delete `scripts/sync-cf-suppression.ts` +
+  `.github/workflows/sync-cf-suppression.yml`; close the Cloudflare Email
+  Sending beta.

--- a/src/env.js
+++ b/src/env.js
@@ -28,19 +28,16 @@ export const env = createEnv({
     GOOGLE_CLIENT_SECRET: z.string(),
     DISCORD_CLIENT_ID: z.string(),
     DISCORD_CLIENT_SECRET: z.string(),
-    // Mailjet (Send API v3.1) — the only email transport now. Drip
-    // (scripts/send-campaign.ts) sends from mail.hackwestern.com; transactional
-    // (signup/verify/reset/application confirmations, src/server/mail-mailjet.ts)
-    // sends from the apex hackwestern.com. Different sending domains keep the
-    // drip's reputation isolated from password-reset/verify even on one account.
-    MAILJET_API_KEY: z.string(),
-    MAILJET_SECRET_KEY: z.string(),
-    // Mailjet Event API webhook (src/pages/api/mailjet-webhook.ts). Mailjet
-    // doesn't sign its payloads, so these credentials are embedded in the
-    // registered webhook URL and verified as HTTP Basic auth on every inbound
-    // event POST — they are the only thing keeping the endpoint private.
-    MAILJET_WEBHOOK_USER: z.string(),
-    MAILJET_WEBHOOK_PASSWORD: z.string(),
+    // Mailjet (Send API v3.1) — the email transport (src/server/mail.ts).
+    // Optional at build time so this branch compiles before the Mailjet account
+    // exists; required at runtime to actually send (sendEmail guards on them).
+    MAILJET_API_KEY: z.string().optional(),
+    MAILJET_SECRET_KEY: z.string().optional(),
+    // Cloudflare Email Service — retained for scripts/sync-cf-suppression.ts
+    // only; the send transport has moved to Mailjet. Retire once suppression
+    // sync is ported (see docs/email-mailjet-migration.md).
+    CLOUDFLARE_EMAIL_API_TOKEN: z.string(),
+    CLOUDFLARE_ACCOUNT_ID: z.string(),
     // Kickbox email-verification API key (optional). When set, signup emails are
     // verified against Kickbox as the final validation layer; unset = skipped.
     KICKBOX_API_KEY: z.string().optional(),
@@ -94,22 +91,14 @@ export const env = createEnv({
     GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
-    MAILJET_API_KEY:
-      process.env.MAILJET_API_KEY ??
-      (process.env.NODE_ENV === "test" ? "mock-mailjet-api-key" : undefined),
-    MAILJET_SECRET_KEY:
-      process.env.MAILJET_SECRET_KEY ??
-      (process.env.NODE_ENV === "test" ? "mock-mailjet-secret-key" : undefined),
-    MAILJET_WEBHOOK_USER:
-      process.env.MAILJET_WEBHOOK_USER ??
-      (process.env.NODE_ENV === "test"
-        ? "mock-mailjet-webhook-user"
-        : undefined),
-    MAILJET_WEBHOOK_PASSWORD:
-      process.env.MAILJET_WEBHOOK_PASSWORD ??
-      (process.env.NODE_ENV === "test"
-        ? "mock-mailjet-webhook-password"
-        : undefined),
+    MAILJET_API_KEY: process.env.MAILJET_API_KEY,
+    MAILJET_SECRET_KEY: process.env.MAILJET_SECRET_KEY,
+    CLOUDFLARE_EMAIL_API_TOKEN:
+      process.env.CLOUDFLARE_EMAIL_API_TOKEN ??
+      (process.env.NODE_ENV === "test" ? "mock-cf-api-token" : undefined),
+    CLOUDFLARE_ACCOUNT_ID:
+      process.env.CLOUDFLARE_ACCOUNT_ID ??
+      (process.env.NODE_ENV === "test" ? "mock-cf-account-id" : undefined),
     KICKBOX_API_KEY: process.env.KICKBOX_API_KEY,
     APPLE_CERT_PASS: process.env.APPLE_CERT_PASS,
     APPLE_WWDR_CERT: process.env.APPLE_WWDR_CERT,

--- a/src/server/mail-mailjet.ts
+++ b/src/server/mail-mailjet.ts
@@ -1,17 +1,4 @@
-export interface SendEmailOptions {
-  to: string | string[];
-  subject: string;
-  html: string;
-  text?: string;
-  from?: string;
-  replyTo?: string;
-  headers?: Record<string, string>;
-}
-
-export interface SendEmailResult {
-  data: { delivered: string[]; queued: string[]; bounced: string[] } | null;
-  error: { message: string } | null;
-}
+import type { SendEmailOptions, SendEmailResult } from "./mail";
 
 /** Mailjet API key + secret for the sending (sub)account. */
 export interface MailjetCreds {

--- a/src/server/mail.ts
+++ b/src/server/mail.ts
@@ -1,0 +1,41 @@
+import { env } from "~/env";
+import { sendViaMailjet } from "./mail-mailjet";
+
+export interface SendEmailOptions {
+  to: string | string[];
+  subject: string;
+  html: string;
+  text?: string;
+  from?: string;
+  replyTo?: string;
+  headers?: Record<string, string>;
+}
+
+export interface SendEmailResult {
+  data: { delivered: string[]; queued: string[]; bounced: string[] } | null;
+  error: { message: string } | null;
+}
+
+/**
+ * Sends an outbound email via Mailjet (Send API v3.1). All app email —
+ * transactional (signup/verify/reset/application confirmations) and the
+ * re-engagement drip — flows through here. Sender identity is set per call via
+ * `options.from`; transactional and marketing use distinct sending subdomains
+ * (and, in Mailjet, distinct subaccounts) so a marketing-complaint spike can't
+ * sink transactional deliverability.
+ */
+export const sendEmail = async (
+  options: SendEmailOptions,
+): Promise<SendEmailResult> => {
+  if (!env.MAILJET_API_KEY || !env.MAILJET_SECRET_KEY) {
+    const message =
+      "Email not sent: MAILJET_API_KEY / MAILJET_SECRET_KEY are not configured.";
+    console.error(message);
+    return { data: null, error: { message } };
+  }
+
+  return sendViaMailjet(options, {
+    apiKey: env.MAILJET_API_KEY,
+    secretKey: env.MAILJET_SECRET_KEY,
+  });
+};


### PR DESCRIPTION
Continuation of #836, closed as a side effect of a \`dev\` history rewrite (same platform limitation as #852/#853/#854/#855).

**This one is genuinely superseded, not just recovered — do not merge.** #836 was explicitly HELD ("do not merge until provisioned"), an earlier attempt at moving transactional email off Cloudflare onto Mailjet. #849 (merged 2026-08-19) already shipped that migration with a different implementation — different env var shape, plus the Mailjet Event API webhook this branch predates entirely.

Restoring this branch required manually keeping its own old \`mail.ts\`/\`mail-mailjet.ts\`/\`env.js\` over what's since landed, so \`tsc\` currently fails (missing \`MAILJET_WEBHOOK_USER\`/\`PASSWORD\`, stale required/optional env shape) — that's expected and correct, not something to fix here. Opened purely so the PR record exists again after the rewrite; keeping it open for historical reference, closing without merging is the right call whenever someone gets to it.