### PR TITLE
chore: gitignore local history-cleanup backlog notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ CLAUDE.md
 
 # local process notes (not committed — keep your own copy)
 PERSON_CONSOLIDATION_NOTES.md
+HISTORY_CLEANUP_BACKLOG.md
 
 
 google-wallet-credentials.json


### PR DESCRIPTION
One-line addition, adds `HISTORY_CLEANUP_BACKLOG.md` to the same local-notes gitignore section as `PERSON_CONSOLIDATION_NOTES.md`. No functional change.