### PR TITLE
feat(email): file contacts into a Mailjet list so campaigns can target them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ HISTORY_CLEANUP_BACKLOG.md
 
 
 google-wallet-credentials.json
+
+# internal docs — public repo, keep operational details out of it
+docs/internal/

--- a/scripts/reconcile-mailjet-contacts.ts
+++ b/scripts/reconcile-mailjet-contacts.ts
@@ -1,0 +1,168 @@
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { emailSubscribers, preregistrations } from "~/server/db/schema";
+import { authHeader } from "~/server/mailjet-contacts";
+import { normalizeEmail } from "~/server/subscribers";
+
+/**
+ * Read-only diff of Mailjet's contacts against our database.
+ *
+ * Answers "why does Mailjet show ~2.5k contacts when email_subscriber has
+ * ~4.9k rows" with an actual set difference rather than an inference, and
+ * prints the buckets that explain it. Writes nothing, anywhere.
+ *
+ * Usage:  npx tsx scripts/reconcile-mailjet-contacts.ts
+ */
+
+const PAGE = 1000;
+
+interface MailjetContact {
+  Email?: string;
+  IsExcludedFromCampaigns?: boolean;
+}
+
+/** Every contact on the account, paged. This is the `All Contacts` view. */
+export async function fetchAllContacts(creds: {
+  apiKey: string;
+  secretKey: string;
+}): Promise<MailjetContact[]> {
+  const all: MailjetContact[] = [];
+  for (let offset = 0; ; offset += PAGE) {
+    const res = await fetch(
+      `https://api.mailjet.com/v3/REST/contact?Limit=${PAGE}&Offset=${offset}`,
+      { headers: { Authorization: authHeader(creds) } },
+    );
+    if (!res.ok) {
+      throw new Error(`Mailjet contact GET ${res.status}: ${await res.text()}`);
+    }
+    const json = (await res.json()) as { Data?: MailjetContact[] };
+    const rows = json.Data ?? [];
+    all.push(...rows);
+    console.log(`  fetched ${all.length}...`);
+    if (rows.length < PAGE) return all;
+  }
+}
+
+function tally<T>(rows: T[], key: (row: T) => string): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const row of rows) {
+    const k = key(row);
+    out.set(k, (out.get(k) ?? 0) + 1);
+  }
+  return out;
+}
+
+async function main() {
+  if (!env.MAILJET_API_KEY || !env.MAILJET_SECRET_KEY) {
+    console.error("MAILJET_API_KEY / MAILJET_SECRET_KEY not set.");
+    process.exit(1);
+  }
+  const creds = {
+    apiKey: env.MAILJET_API_KEY,
+    secretKey: env.MAILJET_SECRET_KEY,
+  };
+
+  console.log("Fetching Mailjet contacts...");
+  const contacts = await fetchAllContacts(creds);
+  // Normalized so the comparison matches how we store addresses; Mailjet
+  // lowercases but does not collapse gmail dots/plus the way normalizeEmail does.
+  const inMailjet = new Set(
+    contacts.map((c) => normalizeEmail(c.Email ?? "")).filter(Boolean),
+  );
+  const excluded = new Set(
+    contacts
+      .filter((c) => c.IsExcludedFromCampaigns)
+      .map((c) => normalizeEmail(c.Email ?? ""))
+      .filter(Boolean),
+  );
+  console.log(
+    `Mailjet: ${contacts.length} contacts (${inMailjet.size} unique after normalizing), ${excluded.size} excluded from campaigns.\n`,
+  );
+
+  const subs = await db
+    .select({
+      email: emailSubscribers.email,
+      source: emailSubscribers.source,
+      unsubscribedAt: emailSubscribers.unsubscribedAt,
+      bouncedAt: emailSubscribers.bouncedAt,
+      lastSentAt: emailSubscribers.lastSentAt,
+    })
+    .from(emailSubscribers);
+  const pre = await db
+    .select({
+      email: preregistrations.email,
+      unsubscribedAt: preregistrations.unsubscribedAt,
+      bouncedAt: preregistrations.bouncedAt,
+    })
+    .from(preregistrations);
+
+  const rows = [
+    ...subs.map((s) => ({
+      email: s.email,
+      cohort: s.source,
+      suppressed: Boolean(s.unsubscribedAt ?? s.bouncedAt),
+      everSent: Boolean(s.lastSentAt),
+    })),
+    ...pre.map((p) => ({
+      email: p.email,
+      cohort: "prereg",
+      suppressed: Boolean(p.unsubscribedAt ?? p.bouncedAt),
+      everSent: false,
+    })),
+  ];
+
+  const missing = rows.filter((r) => !r.suppressed && !inMailjet.has(r.email));
+  const present = rows.filter((r) => inMailjet.has(r.email));
+  const dbEmails = new Set(rows.map((r) => r.email));
+  const orphans = [...inMailjet].filter((e) => !dbEmails.has(e));
+
+  console.log(`Database: ${rows.length} rows across email_subscriber + preregistration.`);
+  console.log(`  in Mailjet:            ${present.length}`);
+  console.log(`  sendable, NOT in Mailjet: ${missing.length}`);
+  console.log(`  in Mailjet, not in DB:    ${orphans.length}\n`);
+
+  console.log("Sendable but missing from Mailjet, by cohort:");
+  for (const [cohort, n] of [...tally(missing, (r) => r.cohort)].sort()) {
+    const neverSent = missing.filter(
+      (r) => r.cohort === cohort && !r.everSent,
+    ).length;
+    console.log(`  ${cohort.padEnd(8)} ${String(n).padStart(5)}  (${neverSent} never sent to)`);
+  }
+
+  console.log("\nPresent in Mailjet, by cohort:");
+  for (const [cohort, n] of [...tally(present, (r) => r.cohort)].sort()) {
+    console.log(`  ${cohort.padEnd(8)} ${String(n).padStart(5)}`);
+  }
+
+  if (orphans.length > 0) {
+    console.log("\nIn Mailjet but absent from our tables (first 20):");
+    orphans.slice(0, 20).forEach((e) => console.log(`  ${e}`));
+  }
+
+  const suppressedButPresent = present.filter((r) => r.suppressed);
+  if (suppressedButPresent.length > 0) {
+    console.log(
+      `\nSuppressed in our DB but still a Mailjet contact: ${suppressedButPresent.length}`,
+    );
+    const alsoExcluded = suppressedButPresent.filter((r) =>
+      excluded.has(r.email),
+    ).length;
+    console.log(
+      `  of which Mailjet also excludes from campaigns: ${alsoExcluded}`,
+    );
+    console.log(
+      `  the remaining ${
+        suppressedButPresent.length - alsoExcluded
+      } would be mailed by a dashboard campaign if added to a list.`,
+    );
+  }
+}
+
+if (process.argv[1]?.includes("reconcile-mailjet-contacts")) {
+  main()
+    .then(() => process.exit(0))
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/scripts/sync-mailjet-list.ts
+++ b/scripts/sync-mailjet-list.ts
@@ -1,0 +1,174 @@
+import { and, isNull, asc, inArray } from "drizzle-orm";
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { emailSubscribers, preregistrations } from "~/server/db/schema";
+import { getContactList, manageContact } from "~/server/mailjet-contacts";
+
+/**
+ * Files our sendable audience into a Mailjet contact list so the marketing
+ * team can target it from the dashboard.
+ *
+ * Background: every contact Mailjet knows about was created implicitly by the
+ * Send API, which files contacts under no list. `My contact lists` therefore
+ * showed 0 for every list while `All Contacts` showed thousands, and a
+ * dashboard campaign — which can only send to a list or to a segment built on
+ * one — had nothing to target. Cohorts the drip never sent to (hw11) and
+ * preregistration signups from before the Cloudflare→Mailjet cutover were not
+ * in Mailjet at all.
+ *
+ * Suppression stays authoritative in our database on the way IN: rows with
+ * unsubscribed_at or bounced_at are never uploaded. Mailjet's own per-list
+ * unsubscribe state is authoritative from then on, which is why every write
+ * uses `addnoforce` — see the note in src/server/mailjet-contacts.ts.
+ *
+ * Usage:  npx tsx scripts/sync-mailjet-list.ts --list=10532038
+ *         npx tsx scripts/sync-mailjet-list.ts --list=10532038 --apply
+ *         npx tsx scripts/sync-mailjet-list.ts --list=10532038 --sources=hw11,hw12 --apply
+ */
+
+const DEFAULT_SOURCES = ["hw12"];
+/** Mailjet REST is generous, but a 2.7k-contact backfill is not worth hammering. */
+const DELAY_MS = 100;
+
+export interface Candidate {
+  email: string;
+  origin: "subscriber" | "preregistration";
+}
+
+/**
+ * The audience: sendable `email_subscriber` rows in the given cohorts, plus
+ * every sendable `preregistration` row. Deduplicated on email — the two tables
+ * are meant to be disjoint but one overlapping address exists in production,
+ * and Mailjet would treat a repeat as a second write rather than an error.
+ */
+export async function selectCandidates(sources: string[]): Promise<Candidate[]> {
+  const subscribers = await db
+    .select({ email: emailSubscribers.email })
+    .from(emailSubscribers)
+    .where(
+      and(
+        isNull(emailSubscribers.unsubscribedAt),
+        isNull(emailSubscribers.bouncedAt),
+        inArray(emailSubscribers.source, sources),
+      ),
+    )
+    .orderBy(asc(emailSubscribers.id));
+
+  const prereg = await db
+    .select({ email: preregistrations.email })
+    .from(preregistrations)
+    .where(
+      and(
+        isNull(preregistrations.unsubscribedAt),
+        isNull(preregistrations.bouncedAt),
+      ),
+    )
+    .orderBy(asc(preregistrations.id));
+
+  const seen = new Set<string>();
+  const out: Candidate[] = [];
+  for (const row of subscribers) {
+    if (seen.has(row.email)) continue;
+    seen.add(row.email);
+    out.push({ email: row.email, origin: "subscriber" });
+  }
+  for (const row of prereg) {
+    if (seen.has(row.email)) continue;
+    seen.add(row.email);
+    out.push({ email: row.email, origin: "preregistration" });
+  }
+  return out;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const listId =
+    process.argv.find((a) => a.startsWith("--list="))?.slice("--list=".length) ??
+    env.MAILJET_CONTACT_LIST_ID;
+  const sources = (
+    process.argv
+      .find((a) => a.startsWith("--sources="))
+      ?.slice("--sources=".length)
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean) ?? DEFAULT_SOURCES
+  ).sort();
+
+  if (!listId) {
+    console.error(
+      "No list ID — pass --list=<id> or set MAILJET_CONTACT_LIST_ID. Find it under Contacts → Contact lists.",
+    );
+    process.exit(1);
+  }
+  if (!env.MAILJET_API_KEY || !env.MAILJET_SECRET_KEY) {
+    console.error("MAILJET_API_KEY / MAILJET_SECRET_KEY not set.");
+    process.exit(1);
+  }
+  const creds = {
+    apiKey: env.MAILJET_API_KEY,
+    secretKey: env.MAILJET_SECRET_KEY,
+  };
+
+  // Confirm the list before writing 2.7k contacts into whatever that ID is.
+  const list = await getContactList(listId, creds);
+  if (!list) {
+    console.error(`Mailjet has no contact list with ID ${listId}.`);
+    process.exit(1);
+  }
+  console.log(
+    `List ${list.id} "${list.name}" — ${list.subscriberCount} contact(s) today.`,
+  );
+
+  const candidates = await selectCandidates(sources);
+  const fromPrereg = candidates.filter(
+    (c) => c.origin === "preregistration",
+  ).length;
+  console.log(
+    `Audience: ${candidates.length} (${
+      candidates.length - fromPrereg
+    } subscriber [${sources.join(", ")}] + ${fromPrereg} preregistration). Mode: ${
+      apply ? "APPLY" : "DRY RUN"
+    }.`,
+  );
+
+  if (!apply) {
+    console.log("DRY RUN — pass --apply to write. First 10:");
+    candidates.slice(0, 10).forEach((c, i) => {
+      console.log(`${i + 1}. ${c.email} (${c.origin})`);
+    });
+    return;
+  }
+
+  let added = 0;
+  const failures: string[] = [];
+  for (const [i, c] of candidates.entries()) {
+    const res = await manageContact(listId, c.email, creds, "addnoforce");
+    if (res.ok) {
+      added++;
+    } else {
+      failures.push(`${c.email}: ${res.error}`);
+      console.log(`FAIL ${c.email} — ${res.error}`);
+    }
+    if ((i + 1) % 100 === 0) {
+      console.log(`  ...${i + 1}/${candidates.length}`);
+    }
+    await sleep(DELAY_MS);
+  }
+
+  console.log(`Done. added ${added}, failed ${failures.length}.`);
+  // addnoforce is idempotent, so the fix for failures is to re-run the script.
+  if (failures.length > 0) {
+    console.log("Re-run to retry the failures — repeat writes are no-ops.");
+  }
+}
+
+if (process.argv[1]?.includes("sync-mailjet-list")) {
+  main()
+    .then(() => process.exit(0))
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/src/env.js
+++ b/src/env.js
@@ -117,7 +117,9 @@ export const env = createEnv({
       (process.env.NODE_ENV === "test"
         ? "mock-mailjet-webhook-password"
         : undefined),
-    MAILJET_CONTACT_LIST_ID: process.env.MAILJET_CONTACT_LIST_ID,
+    MAILJET_CONTACT_LIST_ID:
+      process.env.MAILJET_CONTACT_LIST_ID ??
+      (process.env.NODE_ENV === "test" ? "mock-contact-list-id" : undefined),
     KICKBOX_API_KEY: process.env.KICKBOX_API_KEY,
     APPLE_CERT_PASS: process.env.APPLE_CERT_PASS,
     APPLE_WWDR_CERT: process.env.APPLE_WWDR_CERT,

--- a/src/env.js
+++ b/src/env.js
@@ -41,6 +41,13 @@ export const env = createEnv({
     // event POST — they are the only thing keeping the endpoint private.
     MAILJET_WEBHOOK_USER: z.string(),
     MAILJET_WEBHOOK_PASSWORD: z.string(),
+    // Mailjet contact list the marketing team sends dashboard campaigns to.
+    // The Send API files contacts under no list, so anyone who should be
+    // reachable from the dashboard has to be added explicitly — new signups by
+    // preregistration.create, the existing audience by scripts/sync-mailjet-list.ts.
+    // Optional: unset simply skips the list write, so a missing value can never
+    // fail a signup or a build.
+    MAILJET_CONTACT_LIST_ID: z.string().optional(),
     // Kickbox email-verification API key (optional). When set, signup emails are
     // verified against Kickbox as the final validation layer; unset = skipped.
     KICKBOX_API_KEY: z.string().optional(),
@@ -110,6 +117,7 @@ export const env = createEnv({
       (process.env.NODE_ENV === "test"
         ? "mock-mailjet-webhook-password"
         : undefined),
+    MAILJET_CONTACT_LIST_ID: process.env.MAILJET_CONTACT_LIST_ID,
     KICKBOX_API_KEY: process.env.KICKBOX_API_KEY,
     APPLE_CERT_PASS: process.env.APPLE_CERT_PASS,
     APPLE_WWDR_CERT: process.env.APPLE_WWDR_CERT,

--- a/src/server/api/routers/preregistration.test.ts
+++ b/src/server/api/routers/preregistration.test.ts
@@ -15,7 +15,9 @@ import { emailSubscribers, preregistrations } from "~/server/db/schema";
 import { eq } from "drizzle-orm";
 import { PreregistrationSeeder } from "~/server/db/seed/preregistrationSeeder";
 import * as mailModule from "~/server/mail-mailjet";
+import * as contactsModule from "~/server/mailjet-contacts";
 import { generateUnsubscribeToken, normalizeEmail } from "~/server/subscribers";
+import { env } from "~/env";
 
 const session = await mockSession(db);
 
@@ -30,9 +32,15 @@ const sendEmailSpy = vi.spyOn(mailModule, "sendViaMailjet").mockResolvedValue({
   error: null,
 });
 
+// Same for the contact-list write, so tests never touch the real Mailjet list.
+const manageContactSpy = vi
+  .spyOn(contactsModule, "manageContact")
+  .mockResolvedValue({ ok: true });
+
 describe("preregistration.create", async () => {
   beforeEach(async () => {
     sendEmailSpy.mockClear();
+    manageContactSpy.mockClear();
 
     // Delete by the NORMALIZED address, because that is what create() stores.
     // Deleting by the raw seed address left the row behind, and every later test
@@ -46,6 +54,7 @@ describe("preregistration.create", async () => {
 
   afterEach(() => {
     sendEmailSpy.mockClear();
+    manageContactSpy.mockClear();
   });
 
   test("creates a new preregistration when it does not exist", async () => {
@@ -84,9 +93,39 @@ describe("preregistration.create", async () => {
 
     expect(sendEmailSpy).toHaveBeenCalledTimes(1);
     const arg = sendEmailSpy.mock.calls[0]?.[0];
-    expect(arg?.to).toBe(testPreregistration.email);
+    // NORMALIZED, not the raw input. Mailjet's Send API creates a contact from
+    // whatever address it delivered to, so sending to the raw form files a
+    // second contact for the same mailbox alongside the one managecontact adds.
+    expect(arg?.to).toBe(normalizeEmail(testPreregistration.email));
     expect(arg?.subject).toContain("signed up");
     expect(arg?.html).toBeTruthy();
+  });
+
+  test("files the new signup into the Mailjet contact list, normalized", async () => {
+    await caller.preregistration.create(testPreregistration);
+
+    expect(manageContactSpy).toHaveBeenCalledTimes(1);
+    const [listId, email, , action] = manageContactSpy.mock.calls[0] ?? [];
+    expect(listId).toBe(env.MAILJET_CONTACT_LIST_ID);
+    expect(email).toBe(normalizeEmail(testPreregistration.email));
+    // Default action. addforce would reset IsUnsubscribed and resurrect opt-outs.
+    expect(action).toBeUndefined();
+  });
+
+  // The row is committed before this call, so a Mailjet outage must not turn a
+  // successful signup into an error for the user.
+  test("still succeeds when the Mailjet list write fails", async () => {
+    manageContactSpy.mockResolvedValueOnce({ ok: false, error: "boom" });
+
+    await expect(
+      caller.preregistration.create(testPreregistration),
+    ).resolves.toBeTruthy();
+
+    const row = await db.query.preregistrations.findFirst({
+      where: (p, { eq }) =>
+        eq(p.email, normalizeEmail(testPreregistration.email)),
+    });
+    expect(row).toBeTruthy();
   });
 
   test("does not send a confirmation email when the signup already exists", async () => {

--- a/src/server/api/routers/preregistration.ts
+++ b/src/server/api/routers/preregistration.ts
@@ -4,6 +4,7 @@ import { preregistrations } from "~/server/db/schema";
 import { TRPCError } from "@trpc/server";
 import { db } from "~/server/db";
 import { sendViaMailjet } from "~/server/mail-mailjet";
+import { manageContact } from "~/server/mailjet-contacts";
 import { normalizeEmail, generateUnsubscribeToken } from "~/server/subscribers";
 import { validateSignupEmail } from "~/server/email-validation";
 import { env } from "~/env";
@@ -94,6 +95,26 @@ export const preregistrationRouter = createTRPCRouter({
 
         if (error) {
           console.error("Error sending preregistration email:", error);
+        }
+
+        // File the contact under the marketing list. Sending alone creates the
+        // contact but files it under no list, so dashboard campaigns — which can
+        // only target a list — never see preregistration signups. `addnoforce`
+        // keeps a previous unsubscribe intact if this address opted out before.
+        // Best-effort: the row is already committed, so a Mailjet failure here
+        // must not turn a successful signup into an error for the user.
+        if (env.MAILJET_CONTACT_LIST_ID) {
+          const listed = await manageContact(
+            env.MAILJET_CONTACT_LIST_ID,
+            normalized,
+            { apiKey: env.MAILJET_API_KEY, secretKey: env.MAILJET_SECRET_KEY },
+          );
+          if (!listed.ok) {
+            console.error(
+              "Error adding preregistration to Mailjet list:",
+              listed.error,
+            );
+          }
         }
 
         return createdPreregistration[0];

--- a/src/server/api/routers/preregistration.ts
+++ b/src/server/api/routers/preregistration.ts
@@ -76,13 +76,20 @@ export const preregistrationRouter = createTRPCRouter({
 
         // Send confirmation email. Don't fail the signup if the email bounces —
         // the preregistration is already saved.
+        //
+        // Send to `normalized`, NOT `input.email`. Mailjet's Send API creates a
+        // contact from whatever address it delivered to, so sending to the raw
+        // input filed "Foo.Bar@gmail.com" while the list write below files
+        // "foobar@gmail.com" — two Mailjet contacts for one mailbox, billed and
+        // mailed separately. A prod audit on 2026-08-25 found 2,552 contacts
+        // collapsing to 2,481 unique addresses; this was the cause.
         const { error } = await sendViaMailjet(
           {
             from: "Hack Western Team <hello@hackwestern.com>",
-            to: input.email,
+            to: normalized,
             subject: "You're signed up for Hack Western 13 updates!",
             html: signupTemplate(
-              input.email,
+              normalized,
               `${BASE}/unsubscribe?token=${unsubscribeToken}`,
             ),
             headers: {

--- a/src/server/mailjet-contacts.test.ts
+++ b/src/server/mailjet-contacts.test.ts
@@ -12,19 +12,21 @@ interface Captured {
 
 function stubFetch(body: unknown, ok = true, status = 200) {
   const captured: Captured = { url: "", auth: "", body: "{}", method: "GET" };
-  const fn = vi.fn((url: string | URL, init?: RequestInit): Promise<Response> => {
-    captured.url = String(url);
-    captured.method = init?.method ?? "GET";
-    const headers = (init?.headers ?? {}) as Record<string, string>;
-    captured.auth = headers.Authorization ?? "";
-    captured.body = typeof init?.body === "string" ? init.body : "{}";
-    return Promise.resolve({
-      ok,
-      status,
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(JSON.stringify(body)),
-    } as Response);
-  });
+  const fn = vi.fn(
+    (url: string | URL, init?: RequestInit): Promise<Response> => {
+      captured.url = String(url);
+      captured.method = init?.method ?? "GET";
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      captured.auth = headers.Authorization ?? "";
+      captured.body = typeof init?.body === "string" ? init.body : "{}";
+      return Promise.resolve({
+        ok,
+        status,
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(JSON.stringify(body)),
+      } as Response);
+    },
+  );
   vi.stubGlobal("fetch", fn);
   return captured;
 }

--- a/src/server/mailjet-contacts.test.ts
+++ b/src/server/mailjet-contacts.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getContactList, manageContact } from "~/server/mailjet-contacts";
+
+const CREDS = { apiKey: "pub", secretKey: "priv" };
+
+interface Captured {
+  url: string;
+  auth: string;
+  body: string;
+  method: string;
+}
+
+function stubFetch(body: unknown, ok = true, status = 200) {
+  const captured: Captured = { url: "", auth: "", body: "{}", method: "GET" };
+  const fn = vi.fn((url: string | URL, init?: RequestInit): Promise<Response> => {
+    captured.url = String(url);
+    captured.method = init?.method ?? "GET";
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    captured.auth = headers.Authorization ?? "";
+    captured.body = typeof init?.body === "string" ? init.body : "{}";
+    return Promise.resolve({
+      ok,
+      status,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body)),
+    } as Response);
+  });
+  vi.stubGlobal("fetch", fn);
+  return captured;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("manageContact", () => {
+  test("posts Email + Action to the list's managecontact endpoint", async () => {
+    const captured = stubFetch({ Count: 1, Data: [{ ID: 5 }] });
+    const res = await manageContact("10532038", "a@gmail.com", CREDS);
+
+    expect(res.ok).toBe(true);
+    expect(captured.method).toBe("POST");
+    expect(captured.url).toBe(
+      "https://api.mailjet.com/v3/REST/contactslist/10532038/managecontact",
+    );
+    expect(captured.auth).toBe(
+      `Basic ${Buffer.from("pub:priv").toString("base64")}`,
+    );
+    expect(JSON.parse(captured.body)).toEqual({
+      Email: "a@gmail.com",
+      Action: "addnoforce",
+    });
+  });
+
+  // The whole point of the default. addforce resets IsUnsubscribed to false,
+  // so defaulting to it would silently re-subscribe people who opted out.
+  test("defaults to addnoforce so an existing unsubscribe survives", async () => {
+    const captured = stubFetch({ Count: 1, Data: [{ ID: 5 }] });
+    await manageContact("1", "a@gmail.com", CREDS);
+    expect(JSON.parse(captured.body)).toMatchObject({ Action: "addnoforce" });
+
+    const forced = stubFetch({ Count: 1, Data: [{ ID: 5 }] });
+    await manageContact("1", "a@gmail.com", CREDS, "addforce");
+    expect(JSON.parse(forced.body)).toMatchObject({ Action: "addforce" });
+  });
+
+  // Callers include the signup path, where the row is already committed.
+  test("returns an error instead of throwing on an API failure", async () => {
+    stubFetch({ ErrorMessage: "nope" }, false, 400);
+    const res = await manageContact("1", "a@gmail.com", CREDS);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain("400");
+  });
+
+  test("returns an error instead of throwing when fetch itself rejects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network down"))),
+    );
+    const res = await manageContact("1", "a@gmail.com", CREDS);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain("network down");
+  });
+});
+
+describe("getContactList", () => {
+  test("returns the list's name and subscriber count", async () => {
+    stubFetch({
+      Count: 1,
+      Data: [{ ID: 10532038, Name: "HW13 Announce", SubscriberCount: 2705 }],
+    });
+    const list = await getContactList("10532038", CREDS);
+    expect(list).toEqual({
+      id: 10532038,
+      name: "HW13 Announce",
+      subscriberCount: 2705,
+    });
+  });
+
+  // A wrong ID must stop the backfill, not write 2.7k contacts somewhere else.
+  test("returns null for an unknown list", async () => {
+    stubFetch({ Data: [] }, false, 404);
+    expect(await getContactList("999", CREDS)).toBeNull();
+  });
+
+  test("throws on a non-404 API failure", async () => {
+    stubFetch({ ErrorMessage: "boom" }, false, 500);
+    await expect(getContactList("1", CREDS)).rejects.toThrow("500");
+  });
+});

--- a/src/server/mailjet-contacts.ts
+++ b/src/server/mailjet-contacts.ts
@@ -95,6 +95,9 @@ export async function manageContact(
     }
     return { ok: true };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }

--- a/src/server/mailjet-contacts.ts
+++ b/src/server/mailjet-contacts.ts
@@ -1,0 +1,100 @@
+import type { MailjetCreds } from "~/server/mail-mailjet";
+
+/**
+ * Mailjet contact-list membership (v3 REST), as opposed to sending (v3.1).
+ *
+ * Why this exists: the Send API creates a contact as a side effect of sending
+ * to it, but files it under no list. Mailjet's dashboard campaigns can only
+ * target a *list*, so every contact we created by sending was invisible to
+ * whoever composes the campaign. Everything that should be reachable from the
+ * dashboard has to be put in a list explicitly, which is what this does.
+ */
+
+const BASE = "https://api.mailjet.com/v3/REST/contactslist";
+
+/**
+ * `addnoforce` adds the contact but leaves an existing subscription status
+ * alone; `addforce` adds it AND resets `IsUnsubscribed` to false. Never default
+ * to addforce — it silently resurrects people who opted out, which is the one
+ * failure mode that turns a re-import into a compliance problem.
+ */
+export type ManageAction = "addnoforce" | "addforce" | "remove" | "unsub";
+
+export interface ContactListInfo {
+  id: number;
+  name: string;
+  subscriberCount: number;
+}
+
+export function authHeader(creds: MailjetCreds): string {
+  return `Basic ${Buffer.from(`${creds.apiKey}:${creds.secretKey}`).toString(
+    "base64",
+  )}`;
+}
+
+interface ContactsListRow {
+  ID?: number;
+  Name?: string;
+  SubscriberCount?: number;
+}
+
+/** Look a list up by ID. Used to fail loudly before writing to a wrong/dead list. */
+export async function getContactList(
+  listId: string,
+  creds: MailjetCreds,
+): Promise<ContactListInfo | null> {
+  const res = await fetch(`${BASE}/${encodeURIComponent(listId)}`, {
+    headers: { Authorization: authHeader(creds) },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(
+      `Mailjet contactslist GET ${res.status}: ${await res.text()}`,
+    );
+  }
+  const json = (await res.json()) as { Data?: ContactsListRow[] };
+  const row = json.Data?.[0];
+  if (!row?.ID) return null;
+  return {
+    id: row.ID,
+    name: row.Name ?? "",
+    subscriberCount: row.SubscriberCount ?? 0,
+  };
+}
+
+/**
+ * Add (or unsubscribe/remove) one contact on one list.
+ *
+ * Never throws — callers include the signup path, where a Mailjet outage must
+ * not fail a preregistration that is already committed to our own database.
+ * Idempotent under `addnoforce`, so the backfill script is safe to re-run.
+ */
+export async function manageContact(
+  listId: string,
+  email: string,
+  creds: MailjetCreds,
+  action: ManageAction = "addnoforce",
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const res = await fetch(
+      `${BASE}/${encodeURIComponent(listId)}/managecontact`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: authHeader(creds),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ Email: email, Action: action }),
+      },
+    );
+    if (!res.ok) {
+      return {
+        ok: false,
+        error: `Mailjet managecontact ${res.status}: ${await res.text()}`,
+      };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}


### PR DESCRIPTION
## Problem

Mailjet's Send API creates a contact as a side effect of delivery, but files it under **no list**. Dashboard campaigns can only send to a list (or a segment built on one), so the marketing team had nothing to target: `My contact lists` showed 0 contacts on every list while `All Contacts` showed 2,552.

Preregistration signups were missing for a second reason — they sent through Cloudflare until the Aug 19 transactional cutover, so most never became Mailjet contacts at all.

## Measured gap

`scripts/reconcile-mailjet-contacts.ts` against prod:

```
Mailjet:   2552 contacts (2481 unique after normalizing), 0 excluded
Database:  5054 rows
  sendable, NOT in Mailjet:  2454   (hw11 2174, hw12 172, prereg 108)
  in Mailjet, not in DB:       25
```

The hw12 172 all have a `last_sent_at` — they were sent to on Jul 30, during the Cloudflare era, which created no Mailjet contacts.

## The part that matters for safety

**Mailjet reports zero account-level exclusions.** `IsExcludedFromCampaigns` is false for all 2,552 contacts, and 32 addresses we have suppressed in Postgres are already Mailjet contacts. Our `unsubscribed_at` / `bounced_at` columns are the only suppression that exists, so the list has to be built from the database rather than from Mailjet's own contact pool.

Every write uses `addnoforce`. `addforce` resets `IsUnsubscribed` to false and would silently resurrect opt-outs — that default is pinned by a test.

## Changes

- `src/server/mailjet-contacts.ts` — `manageContact` / `getContactList` (v3 REST). Never throws; the signup path calls it after the row is already committed.
- `scripts/sync-mailjet-list.ts` — backfill. Dry run by default, verifies the target list exists before writing, idempotent so a partial run is just re-run.
- `scripts/reconcile-mailjet-contacts.ts` — read-only diff, writes nothing.
- `preregistration.create` — files new signups into the list, best-effort.
- `MAILJET_CONTACT_LIST_ID` — **optional**, so an unset value cannot fail a signup or a build.

## Already applied to production Mailjet

List `HW13 Announce` (ID `10590852`) created and backfilled: **2,705 contacts, 0 failures** (2,573 hw12 + 132 prereg). Spot-checked that a bounced hw12 address, an unsubscribed hw12 address, and an unsubscribed prereg address are all absent, and a sendable prereg address is present.

`MAILJET_CONTACT_LIST_ID=10590852` needs setting in the Vercel production environment for the signup hook to do anything.

## Verification

- 7 new tests pass (`src/server/mailjet-contacts.test.ts`)
- `tsc --noEmit` clean
- `eslint` clean on all touched files
- DB-integration suite **not run** — no dev database available in this worktree, and it was not pointed at production