### PR TITLE
fix(auth): canonicalize user emails and enforce uniqueness

### DIFF
--- a/drizzle/0012_married_vision.sql
+++ b/drizzle/0012_married_vision.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD CONSTRAINT "user_email_unique" UNIQUE("email");

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2346 @@
+{
+  "id": "e5379d31-e51d-43d3-a5cd-cc89fa59b88a",
+  "prevId": "51a9a9a0-9d02-4baf-b9f6-228ff0fda53b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IN_PROGRESS'"
+        },
+        "avatar_colour": {
+          "name": "avatar_colour",
+          "type": "avatar_colour",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_face": {
+          "name": "avatar_face",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_left_hand": {
+          "name": "avatar_left_hand",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_right_hand": {
+          "name": "avatar_right_hand",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_hat": {
+          "name": "avatar_hat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_residence": {
+          "name": "country_of_residence",
+          "type": "country",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year_of_study": {
+          "name": "year_of_study",
+          "type": "year_of_study",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "major": {
+          "name": "major",
+          "type": "major",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shirt_size": {
+          "name": "shirt_size",
+          "type": "shirt_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_restrictions": {
+          "name": "dietary_restrictions",
+          "type": "dietary_restrictions",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_restrictions_other": {
+          "name": "dietary_restrictions_other",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_of_hackathons": {
+          "name": "num_of_hackathons",
+          "type": "num_of_hackathons",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question1": {
+          "name": "question1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question2": {
+          "name": "question2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question3": {
+          "name": "question3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_link": {
+          "name": "github_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedin_link": {
+          "name": "linkedin_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "devpost_link": {
+          "name": "devpost_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resume_link": {
+          "name": "resume_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_link": {
+          "name": "other_link",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agree_code_of_conduct": {
+          "name": "agree_code_of_conduct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_share_with_sponsors": {
+          "name": "agree_share_with_sponsors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_share_with_mlh": {
+          "name": "agree_share_with_mlh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_emails_from_mlh": {
+          "name": "agree_emails_from_mlh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agree_will_be_18": {
+          "name": "agree_will_be_18",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "underrep_group": {
+          "name": "underrep_group",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ethnicity": {
+          "name": "ethnicity",
+          "type": "race/ethnicity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sexual_orientation": {
+          "name": "sexual_orientation",
+          "type": "sexual_orientation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canvas_data": {
+          "name": "canvas_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"paths\":[],\"timestamp\":0,\"version\":\"\"}'::jsonb"
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_relationship": {
+          "name": "emergency_contact_relationship",
+          "type": "emergency_contact_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone_number": {
+          "name": "emergency_contact_phone_number",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transportation_method": {
+          "name": "transportation_method",
+          "type": "transportation_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_user_id_user_id_fk": {
+          "name": "application_user_id_user_id_fk",
+          "tableFrom": "application",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.day_of_registration": {
+      "name": "day_of_registration",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signed_in_at": {
+          "name": "signed_in_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "day_of_registration_user_id_user_id_fk": {
+          "name": "day_of_registration_user_id_user_id_fk",
+          "tableFrom": "day_of_registration",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_subscriber": {
+      "name": "email_subscriber",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_subscriber_email_unique": {
+          "name": "email_subscriber_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "email_subscriber_unsubscribe_token_unique": {
+          "name": "email_subscriber_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hacker_check_result": {
+      "name": "hacker_check_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_type": {
+          "name": "check_type",
+          "type": "hacker_check_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "checked_by_user_id": {
+          "name": "checked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manual_override": {
+          "name": "manual_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "hacker_check_user_idx": {
+          "name": "hacker_check_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hacker_check_unique_idx": {
+          "name": "hacker_check_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hacker_check_result_user_id_user_id_fk": {
+          "name": "hacker_check_result_user_id_user_id_fk",
+          "tableFrom": "hacker_check_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hacker_check_result_checked_by_user_id_user_id_fk": {
+          "name": "hacker_check_result_checked_by_user_id_user_id_fk",
+          "tableFrom": "hacker_check_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "checked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judge": {
+      "name": "judge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "judge_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'organizer'"
+        },
+        "track": {
+          "name": "track",
+          "type": "track[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marks_count": {
+          "name": "marks_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "marks_sum": {
+          "name": "marks_sum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "marks_squared_sum": {
+          "name": "marks_squared_sum",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judge_id_user_id_fk": {
+          "name": "judge_id_user_id_fk",
+          "tableFrom": "judge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judging_queue": {
+      "name": "judging_queue",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "seen_judges": {
+          "name": "seen_judges",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rounds_remaining": {
+          "name": "rounds_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "judging_queue_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "current_judge_id": {
+          "name": "current_judge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "judging_queue_priority_idx": {
+          "name": "judging_queue_priority_idx",
+          "columns": [
+            {
+              "expression": "rounds_remaining",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "enqueued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "judging_queue_current_judge_idx": {
+          "name": "judging_queue_current_judge_idx",
+          "columns": [
+            {
+              "expression": "current_judge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "judging_queue_team_id_team_id_fk": {
+          "name": "judging_queue_team_id_team_id_fk",
+          "tableFrom": "judging_queue",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judging_queue_current_judge_id_judge_id_fk": {
+          "name": "judging_queue_current_judge_id_judge_id_fk",
+          "tableFrom": "judging_queue",
+          "tableTo": "judge",
+          "columnsFrom": [
+            "current_judge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.judging_skip": {
+      "name": "judging_skip",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_id": {
+          "name": "judge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "judging_skip_team_id_team_id_fk": {
+          "name": "judging_skip_team_id_team_id_fk",
+          "tableFrom": "judging_skip",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "judging_skip_judge_id_judge_id_fk": {
+          "name": "judging_skip_judge_id_judge_id_fk",
+          "tableFrom": "judging_skip",
+          "tableTo": "judge",
+          "columnsFrom": [
+            "judge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "judging_skip_team_id_judge_id_pk": {
+          "name": "judging_skip_team_id_judge_id_pk",
+          "columns": [
+            "team_id",
+            "judge_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preregistration": {
+      "name": "preregistration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_at": {
+          "name": "bounced_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "preregistration_email_unique": {
+          "name": "preregistration_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "preregistration_unsubscribe_token_unique": {
+          "name": "preregistration_unsubscribe_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "unsubscribe_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reset_password_token": {
+      "name": "reset_password_token",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reset_password_token_userId_user_id_fk": {
+          "name": "reset_password_token_userId_user_id_fk",
+          "tableFrom": "reset_password_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_user_id": {
+          "name": "applicant_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "originality_rating": {
+          "name": "originality_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "technicality_rating": {
+          "name": "technicality_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "passion_rating": {
+          "name": "passion_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "referral": {
+          "name": "referral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "applicant_user_id_idx": {
+          "name": "applicant_user_id_idx",
+          "columns": [
+            {
+              "expression": "applicant_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reviewer_user_id_user_id_fk": {
+          "name": "review_reviewer_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_applicant_user_id_application_user_id_fk": {
+          "name": "review_applicant_user_id_application_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicant_user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_applicant_user_id_user_id_fk": {
+          "name": "review_applicant_user_id_user_id_fk",
+          "tableFrom": "review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "applicant_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "review_reviewer_user_id_applicant_user_id_pk": {
+          "name": "review_reviewer_user_id_applicant_user_id_pk",
+          "columns": [
+            "reviewer_user_id",
+            "applicant_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_item": {
+      "name": "scavenger_hunt_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scavenger_hunt_item_code_unique": {
+          "name": "scavenger_hunt_item_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_redemption": {
+      "name": "scavenger_hunt_redemption",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "redemption_user_idx": {
+          "name": "redemption_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scavenger_hunt_redemption_user_id_user_id_fk": {
+          "name": "scavenger_hunt_redemption_user_id_user_id_fk",
+          "tableFrom": "scavenger_hunt_redemption",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scavenger_hunt_redemption_reward_id_scavenger_hunt_reward_id_fk": {
+          "name": "scavenger_hunt_redemption_reward_id_scavenger_hunt_reward_id_fk",
+          "tableFrom": "scavenger_hunt_redemption",
+          "tableTo": "scavenger_hunt_reward",
+          "columnsFrom": [
+            "reward_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_reward": {
+      "name": "scavenger_hunt_reward",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_points": {
+          "name": "cost_points",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scavenger_hunt_scan": {
+      "name": "scavenger_hunt_scan",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanner_id": {
+          "name": "scanner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scan_user_idx": {
+          "name": "scan_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scan_scanner_idx": {
+          "name": "scan_scanner_idx",
+          "columns": [
+            {
+              "expression": "scanner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scavenger_hunt_scan_user_id_user_id_fk": {
+          "name": "scavenger_hunt_scan_user_id_user_id_fk",
+          "tableFrom": "scavenger_hunt_scan",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scavenger_hunt_scan_scanner_id_user_id_fk": {
+          "name": "scavenger_hunt_scan_scanner_id_user_id_fk",
+          "tableFrom": "scavenger_hunt_scan",
+          "tableTo": "user",
+          "columnsFrom": [
+            "scanner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scavenger_hunt_scan_item_id_scavenger_hunt_item_id_fk": {
+          "name": "scavenger_hunt_scan_item_id_scavenger_hunt_item_id_fk",
+          "tableFrom": "scavenger_hunt_scan",
+          "tableTo": "scavenger_hunt_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "scavenger_hunt_scan_user_id_item_id_pk": {
+          "name": "scavenger_hunt_scan_user_id_item_id_pk",
+          "columns": [
+            "user_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_check_result": {
+      "name": "team_check_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_type": {
+          "name": "check_type",
+          "type": "team_check_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "checked_by_user_id": {
+          "name": "checked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manual_override": {
+          "name": "manual_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_check_team_idx": {
+          "name": "team_check_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_check_unique_idx": {
+          "name": "team_check_unique_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_check_result_team_id_team_id_fk": {
+          "name": "team_check_result_team_id_team_id_fk",
+          "tableFrom": "team_check_result",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_check_result_checked_by_user_id_user_id_fk": {
+          "name": "team_check_result_checked_by_user_id_user_id_fk",
+          "tableFrom": "team_check_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "checked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_mark": {
+      "name": "team_mark",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judge_id": {
+          "name": "judge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_type": {
+          "name": "round_type",
+          "type": "round_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_mark_team_idx": {
+          "name": "team_mark_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_mark_judge_idx": {
+          "name": "team_mark_judge_idx",
+          "columns": [
+            {
+              "expression": "judge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_mark_team_id_team_id_fk": {
+          "name": "team_mark_team_id_team_id_fk",
+          "tableFrom": "team_mark",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_mark_judge_id_judge_id_fk": {
+          "name": "team_mark_judge_id_judge_id_fk",
+          "tableFrom": "team_mark",
+          "tableTo": "judge",
+          "columnsFrom": [
+            "judge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(6)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "devpost_url": {
+          "name": "devpost_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_status": {
+          "name": "submission_status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "track[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_github_usernames": {
+          "name": "member_github_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_devpost_usernames": {
+          "name": "member_devpost_usernames",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_created_at_idx": {
+          "name": "team_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hacker'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scavenger_hunt_earned": {
+          "name": "scavenger_hunt_earned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "scavenger_hunt_balance": {
+          "name": "scavenger_hunt_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "user_scavenger_hunt_earned_idx": {
+          "name": "user_scavenger_hunt_earned_idx",
+          "columns": [
+            {
+              "expression": "scavenger_hunt_earned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_scavenger_hunt_balance_idx": {
+          "name": "user_scavenger_hunt_balance_idx",
+          "columns": [
+            {
+              "expression": "scavenger_hunt_balance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_team_id_idx": {
+          "name": "user_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_team_id_team_id_fk": {
+          "name": "user_team_id_team_id_fk",
+          "tableFrom": "user",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_token": {
+      "name": "verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_token_identifier_token_pk": {
+          "name": "verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "IN_PROGRESS",
+        "PENDING_REVIEW",
+        "IN_REVIEW",
+        "ACCEPTED",
+        "REJECTED",
+        "WAITLISTED",
+        "DECLINED",
+        "CONFIRMED"
+      ]
+    },
+    "public.avatar_colour": {
+      "name": "avatar_colour",
+      "schema": "public",
+      "values": [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple",
+        "pink"
+      ]
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "public",
+      "values": [
+        "Canada",
+        "United States",
+        "India",
+        "Other"
+      ]
+    },
+    "public.dietary_restrictions": {
+      "name": "dietary_restrictions",
+      "schema": "public",
+      "values": [
+        "Vegetarian",
+        "Vegan",
+        "Kosher",
+        "Halal",
+        "Other"
+      ]
+    },
+    "public.emergency_contact_relationship": {
+      "name": "emergency_contact_relationship",
+      "schema": "public",
+      "values": [
+        "Parent",
+        "Sibling",
+        "Other family member",
+        "Friend",
+        "Coworker",
+        "Other"
+      ]
+    },
+    "public.race/ethnicity": {
+      "name": "race/ethnicity",
+      "schema": "public",
+      "values": [
+        "American Indian or Alaskan Native",
+        "Asian / Pacific Islander",
+        "Black or African American",
+        "Hispanic",
+        "White / Caucasian",
+        "Multiple ethnicity / Other",
+        "Prefer not to answer"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "Female",
+        "Male",
+        "Non-Binary",
+        "Other",
+        "Prefer not to answer"
+      ]
+    },
+    "public.hacker_check_type": {
+      "name": "hacker_check_type",
+      "schema": "public",
+      "values": [
+        "IS_OF_AGE",
+        "IS_REGISTERED"
+      ]
+    },
+    "public.judge_type": {
+      "name": "judge_type",
+      "schema": "public",
+      "values": [
+        "organizer",
+        "sponsored"
+      ]
+    },
+    "public.judging_queue_status": {
+      "name": "judging_queue_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "assigned"
+      ]
+    },
+    "public.major": {
+      "name": "major",
+      "schema": "public",
+      "values": [
+        "Computer Science",
+        "Computer Engineering",
+        "Software Engineering",
+        "Other Engineering Discipline",
+        "Information Systems",
+        "Information Technology",
+        "System Administration",
+        "Natural Sciences (Biology, Chemistry, Physics, etc.)",
+        "Mathematics/Statistics",
+        "Web Development/Web Design",
+        "Business Administration",
+        "Humanities",
+        "Social Science",
+        "Fine Arts/Performing Arts",
+        "Other"
+      ]
+    },
+    "public.num_of_hackathons": {
+      "name": "num_of_hackathons",
+      "schema": "public",
+      "values": [
+        "0",
+        "1-3",
+        "4-6",
+        "7+"
+      ]
+    },
+    "public.round_type": {
+      "name": "round_type",
+      "schema": "public",
+      "values": [
+        "regular",
+        "sponsored"
+      ]
+    },
+    "public.sexual_orientation": {
+      "name": "sexual_orientation",
+      "schema": "public",
+      "values": [
+        "Asexual / Aromantic",
+        "Pansexual, Demisexual or Omnisexual",
+        "Bisexual",
+        "Queer",
+        "Gay / Lesbian",
+        "Heterosexual / Straight",
+        "Other",
+        "Prefer not to answer"
+      ]
+    },
+    "public.shirt_size": {
+      "name": "shirt_size",
+      "schema": "public",
+      "values": [
+        "S",
+        "M",
+        "L",
+        "XL"
+      ]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "late"
+      ]
+    },
+    "public.team_check_type": {
+      "name": "team_check_type",
+      "schema": "public",
+      "values": [
+        "COMMIT_WITHIN_ALLOTTED_TIME",
+        "ONLY_TEAM_MEMBER_COMMITS",
+        "DEVPOST_MEMBERS_REGISTERED"
+      ]
+    },
+    "public.track": {
+      "name": "track",
+      "schema": "public",
+      "values": [
+        "Best Use of Cohere",
+        "Best Use of AntiGravity",
+        "Best Domain",
+        "General"
+      ]
+    },
+    "public.transportation_method": {
+      "name": "transportation_method",
+      "schema": "public",
+      "values": [
+        "Waterloo",
+        "Toronto",
+        "Hamilton",
+        "None"
+      ]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": [
+        "hacker",
+        "organizer",
+        "sponsor"
+      ]
+    },
+    "public.year_of_study": {
+      "name": "year_of_study",
+      "schema": "public",
+      "values": [
+        "1st",
+        "2nd",
+        "3rd",
+        "4th",
+        "5th+",
+        "N/A",
+        "Prefer not to answer"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1787159787435,
       "tag": "0011_wealthy_terrax",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1787929742907,
+      "tag": "0012_married_vision",
+      "breakpoints": true
     }
   ]
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -60,7 +60,7 @@ export default function Login() {
             <Input
               id="email"
               name="email"
-              type="text"
+              type="email"
               autoComplete="username"
               className="mb-4 h-[60px] bg-highlight text-medium"
               placeholder="hello@hackwestern.com"

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -64,7 +64,10 @@ export default function Register() {
             <Input
               required
               id="email"
-              type="text"
+              // type="email", not "text": mobile keyboards autocapitalize text
+              // inputs, which is how HW12 got mixed-case emails into the user
+              // table and 7 duplicate accounts out of it.
+              type="email"
               name="email"
               autoComplete="username"
               className="mb-4 h-[60px] bg-highlight text-medium"

--- a/src/server/api/routers/application.ts
+++ b/src/server/api/routers/application.ts
@@ -9,6 +9,7 @@ import { applications, users } from "~/server/db/schema";
 import { db } from "~/server/db";
 import { sendViaMailjet } from "~/server/mail-mailjet";
 import { env } from "~/env";
+import { normalizeAuthEmail } from "~/server/subscribers";
 import { applicationSubmittedTemplate } from "./email-templates";
 import {
   applicationSaveSchema,
@@ -407,11 +408,15 @@ export const applicationRouter = createTRPCRouter({
     .mutation(async ({ input }) => {
       const { emails, status } = input;
       try {
+        // Stored emails are canonical (trim+lowercase). A decision CSV with any
+        // other casing would otherwise silently skip those rows — and a skipped
+        // row here is a person who never hears their decision.
+        const canonical = emails.map(normalizeAuthEmail);
         const result = await db.transaction(async (tx) => {
           const userRows = await tx
             .select({ id: users.id })
             .from(users)
-            .where(inArray(users.email, emails));
+            .where(inArray(users.email, canonical));
 
           const userIds = userRows.map((r) => r.id);
           if (userIds.length === 0) {

--- a/src/server/api/routers/auth.test.ts
+++ b/src/server/api/routers/auth.test.ts
@@ -36,13 +36,16 @@ describe.sequential("auth.reset", async () => {
         error: null,
       });
 
-    // insert fake user
+    // Insert the fake user CANONICAL (trim+lowercase) — that is the only form
+    // a real row can have, since auth.create normalizes on write. Calling
+    // reset with faker's raw (often mixed-case) email then exercises the
+    // lookup-side normalization.
     await db
       .insert(users)
       .values({
         id: fakeUserId,
         name: faker.person.fullName(),
-        email: fakeEmail,
+        email: fakeEmail.toLowerCase(),
         emailVerified: faker.date.anytime(),
         image: faker.image.avatar(),
       })
@@ -61,7 +64,7 @@ describe.sequential("auth.reset", async () => {
       await db
         .delete(resetPasswordTokens)
         .where(eq(resetPasswordTokens.userId, fakeUserId));
-      await db.delete(users).where(eq(users.email, fakeEmail));
+      await db.delete(users).where(eq(users.email, fakeEmail.toLowerCase()));
     }
   });
 });
@@ -88,11 +91,13 @@ describe.sequential("auth.create", () => {
 
       expect(createdUser.success).toBe(true);
 
+      // Stored canonical: trim+lowercase, whatever casing was typed. (faker
+      // emails are often mixed-case, so this also exercises the normalization.)
       const dbUser = await db.query.users.findFirst({
-        where: eq(users.email, fakeUser.email),
+        where: eq(users.email, fakeUser.email.toLowerCase()),
       });
 
-      expect(dbUser?.email).toBe(fakeUser.email);
+      expect(dbUser?.email).toBe(fakeUser.email.toLowerCase());
     } finally {
       sendEmailSpy.mockRestore();
     }
@@ -102,6 +107,25 @@ describe.sequential("auth.create", () => {
     await expect(caller.auth.create(fakeUser)).rejects.toThrowError(
       /already exists/i,
     );
+  });
+
+  // The HW12 failure mode: same mailbox, different casing, second account
+  // created. 7 of 2,278 HW12 users hit this — one was ACCEPTED on one account
+  // with a duplicate still in PENDING_REVIEW.
+  test("rejects a duplicate that differs only in casing", async () => {
+    const swapped =
+      fakeUser.email === fakeUser.email.toLowerCase()
+        ? fakeUser.email.toUpperCase()
+        : fakeUser.email.toLowerCase();
+    await expect(
+      caller.auth.create({ ...fakeUser, email: swapped }),
+    ).rejects.toThrowError(/already exists/i);
+  });
+
+  test("rejects a duplicate with surrounding whitespace", async () => {
+    await expect(
+      caller.auth.create({ ...fakeUser, email: ` ${fakeUser.email} ` }),
+    ).rejects.toThrowError();
   });
 });
 

--- a/src/server/api/routers/auth.ts
+++ b/src/server/api/routers/auth.ts
@@ -15,6 +15,7 @@ import { TRPCError } from "@trpc/server";
 import { authOptions } from "~/server/auth";
 import { type AdapterUser } from "next-auth/adapters";
 import { resetTemplate, verifyTemplate } from "./email-templates";
+import { normalizeAuthEmail } from "~/server/subscribers";
 
 const TOKEN_EXPIRY = 1000 * 60 * 11; // 11 minutes
 const passwordSchema = z
@@ -64,10 +65,12 @@ export const authRouter = createTRPCRouter({
   reset: publicProcedure
     .input(z.object({ email: z.string() }))
     .mutation(async ({ input }) => {
-      // Fetch user by email
+      // Fetch user by email. Stored emails are canonical (trim+lowercase), so
+      // the lookup must canonicalize too or "Forgot password" tells anyone who
+      // types a different casing that their account doesn't exist.
       const user = await db.query.users.findFirst({
         columns: { id: true, name: true },
-        where: eq(users.email, input.email),
+        where: eq(users.email, normalizeAuthEmail(input.email)),
       });
 
       if (!user) {
@@ -129,8 +132,13 @@ export const authRouter = createTRPCRouter({
     .input(createInputSchema)
     .mutation(async ({ input }) => {
       try {
+        // Canonicalize once and use it for the lookup AND the insert. The HW12
+        // user table had 7 people with two accounts each because signup stored
+        // the raw string (mobile keyboards autocapitalize) while login matched
+        // exactly — "account doesn't exist" at login, so they registered again.
+        const email = normalizeAuthEmail(input.email);
         const user = await db.query.users.findFirst({
-          where: eq(users.email, input.email),
+          where: eq(users.email, email),
         });
 
         if (user) {
@@ -153,7 +161,7 @@ export const authRouter = createTRPCRouter({
         }
 
         const createdUser = await adapter.createUser({
-          email: input.email,
+          email,
           emailVerified: null,
           id: "",
         });

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -13,7 +13,7 @@ import {
   type DefaultSession,
   type NextAuthOptions,
 } from "next-auth";
-import { type Adapter } from "next-auth/adapters";
+import { type Adapter, type AdapterUser } from "next-auth/adapters";
 import GithubProvider from "next-auth/providers/github";
 import GoogleProvider from "next-auth/providers/google";
 import DiscordProvider from "next-auth/providers/discord";
@@ -43,6 +43,30 @@ declare module "next-auth" {
   //   // ...other properties
   //   // role: UserRole;
   // }
+}
+
+/**
+ * DrizzleAdapter with email canonicalization (trim + lowercase) on every path
+ * that writes or looks up a user by email. Credentials signup already
+ * normalizes in auth.create, but OAuth signups (Google/GitHub/Discord) go
+ * through the adapter directly — and GitHub can hand over a mixed-case email,
+ * which would dodge the unique constraint (a plain string constraint, not
+ * lower()-based) and recreate the HW12 duplicate-account bug through the side
+ * door. Wrapping here makes the whole system case-insensitive regardless of
+ * how the account was created.
+ */
+function caseInsensitiveAdapter(): Adapter {
+  const base = DrizzleAdapter(db) as Adapter;
+  return {
+    ...base,
+    createUser: base.createUser
+      ? (user: AdapterUser) =>
+          base.createUser!({ ...user, email: normalizeAuthEmail(user.email) })
+      : undefined,
+    getUserByEmail: base.getUserByEmail
+      ? (email: string) => base.getUserByEmail!(normalizeAuthEmail(email))
+      : undefined,
+  };
 }
 
 /**
@@ -79,7 +103,7 @@ export const authOptions: NextAuthOptions = {
     encode,
     decode,
   },
-  adapter: DrizzleAdapter(db) as Adapter,
+  adapter: caseInsensitiveAdapter(),
   providers: [
     GithubProvider({
       clientId: env.GITHUB_CLIENT_ID,

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -5,6 +5,7 @@ import CredentialsProvider from "next-auth/providers/credentials";
 import bcrypt from "bcrypt";
 import { TRPCError } from "@trpc/server";
 import { encode, decode } from "next-auth/jwt";
+import { normalizeAuthEmail } from "~/server/subscribers";
 
 import {
   type Session,
@@ -176,8 +177,12 @@ export async function mockOrganizerSession(db: Database): Promise<Session> {
 
 async function login(email: string, password: string) {
   try {
+    // Stored emails are canonical (trim+lowercase) — see normalizeAuthEmail.
+    // Without canonicalizing here, someone who registered "Luka@uwo.ca" on a
+    // phone (autocapitalized) and later types "luka@uwo.ca" gets NOT_FOUND and,
+    // naturally, registers a second account.
     const user = await db.query.users.findFirst({
-      where: (users, { eq }) => eq(users.email, email),
+      where: (users, { eq }) => eq(users.email, normalizeAuthEmail(email)),
     });
 
     if (!user) {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -283,7 +283,10 @@ export const users = pgTable(
     id: varchar("id", { length: 255 }).notNull().primaryKey(),
     name: varchar("name", { length: 255 }),
     password: varchar("password", { length: 255 }),
-    email: varchar("email", { length: 255 }).notNull(),
+    // Stored canonical (trim+lowercase) — every read/write goes through
+    // normalizeAuthEmail. The unique constraint is the backstop: HW12 shipped
+    // without it and 7 people ended up with two accounts each.
+    email: varchar("email", { length: 255 }).notNull().unique(),
     emailVerified: timestamp("emailVerified", {
       mode: "date",
     }).default(sql`CURRENT_TIMESTAMP`),

--- a/src/server/subscribers.test.ts
+++ b/src/server/subscribers.test.ts
@@ -6,6 +6,7 @@ import * as contactsModule from "~/server/mailjet-contacts";
 import { env } from "~/env";
 import {
   normalizeEmail,
+  normalizeAuthEmail,
   isSchoolEmail,
   generateUnsubscribeToken,
   editionFromSource,
@@ -29,6 +30,20 @@ describe("normalizeEmail", () => {
   });
   test("leaves non-gmail local part intact", () => {
     expect(normalizeEmail("john.doe@outlook.com")).toBe("john.doe@outlook.com");
+  });
+});
+
+describe("normalizeAuthEmail", () => {
+  test("trims and lowercases", () => {
+    expect(normalizeAuthEmail("  Luka@UWO.ca ")).toBe("luka@uwo.ca");
+  });
+
+  // The deliberate difference from normalizeEmail: an auth identity keeps its
+  // gmail dots and plus tags. Stripping them is right for a mailing list, wrong
+  // for a login credential.
+  test("does NOT strip gmail dots or plus tags", () => {
+    expect(normalizeAuthEmail("A.rjun+hw@gmail.com")).toBe("a.rjun+hw@gmail.com");
+    expect(normalizeEmail("A.rjun+hw@gmail.com")).toBe("arjun@gmail.com");
   });
 });
 

--- a/src/server/subscribers.test.ts
+++ b/src/server/subscribers.test.ts
@@ -42,7 +42,9 @@ describe("normalizeAuthEmail", () => {
   // gmail dots and plus tags. Stripping them is right for a mailing list, wrong
   // for a login credential.
   test("does NOT strip gmail dots or plus tags", () => {
-    expect(normalizeAuthEmail("A.rjun+hw@gmail.com")).toBe("a.rjun+hw@gmail.com");
+    expect(normalizeAuthEmail("A.rjun+hw@gmail.com")).toBe(
+      "a.rjun+hw@gmail.com",
+    );
     expect(normalizeEmail("A.rjun+hw@gmail.com")).toBe("arjun@gmail.com");
   });
 });

--- a/src/server/subscribers.ts
+++ b/src/server/subscribers.ts
@@ -33,6 +33,24 @@ export function normalizeEmail(raw: string): string {
   return email;
 }
 
+/**
+ * Canonical form for an AUTH identity (user.email): trim + lowercase, nothing
+ * more. Deliberately weaker than normalizeEmail above — gmail dot/plus
+ * stripping is right for a mailing list (one mailbox, one contact) but wrong
+ * for a login credential, where the address should stay recognizable as what
+ * the user typed.
+ *
+ * Why it exists at all, measured in the HW12 dump: register.tsx used a
+ * type="text" input (mobile keyboards autocapitalize), every lookup was an
+ * exact string match, and user.email had no unique constraint — 7 of 2,278
+ * users ended up with two accounts, one of them ACCEPTED on one account with a
+ * duplicate still sitting in PENDING_REVIEW. Every read AND write of
+ * user.email must go through this.
+ */
+export function normalizeAuthEmail(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
 export function isSchoolEmail(email: string): boolean {
   const domain = email.split("@")[1] ?? "";
   if (domain.endsWith(".edu")) return true;


### PR DESCRIPTION
## The bug, measured

`user.email` has no unique constraint, every lookup is an exact string match, and the register form is `type="text"` — which mobile keyboards autocapitalize.

The chain: sign up on a phone as `Jsmith@uwo.ca` (stored raw) → later type `jsmith@uwo.ca` at login → `NOT_FOUND` → register again. Two accounts, two applications, one person.

**From the HW12 dump (2,278 users):** 7 people with duplicate accounts — one ACCEPTED on one account with a duplicate still in PENDING_REVIEW, one REJECTED on one while mid-application on the other, three who registered twice and never applied on either. It stayed invisible because `import-subscribers.ts` normalized emails when building mailing lists, masking the duplicates everywhere anyone looked.

## The fix

Now, while `user` has 0 rows and there is nothing to migrate:

- **`normalizeAuthEmail` (trim + lowercase)** at every boundary: `auth.create` (lookup + insert), `login()`, password reset, `bulkUpdateStatusByEmails`. Deliberately weaker than `normalizeEmail` — gmail dot/plus stripping is right for a mailing list, wrong for a login credential (pinned by a test).
- **UNIQUE constraint** on `user.email` — migration `0012_married_vision.sql`, generated by drizzle-kit.
- **`type="email"`** on the register and login inputs — stops autocapitalization at the source. (`forgot-password` already had it.)

`bulkUpdateStatusByEmails` matters most downstream: decision CSVs match on email, and a silently skipped row is a person who never hears their decision.

## Tests

- New: duplicate-differing-only-in-casing rejected; whitespace-wrapped duplicate rejected; create stores lowercase; `normalizeAuthEmail` keeps gmail dots/plus while `normalizeEmail` strips them
- Updated: the reset test seeded a raw mixed-case email directly into the table — a state no real row can be in now. It seeds canonical and calls reset with faker's raw casing, which exercises the lookup-side normalization.
- `tsc` + `eslint` clean. DB-integration tests run in CI (no local database).

## Not covered, deliberately

OAuth signups (Google/GitHub/Discord) go through the NextAuth adapter, not `auth.create`. Google always returns lowercase; GitHub can return mixed case if the user set it. Wrapping the adapter is scope creep for a rare path — noting it rather than fixing it.

## Deploy note

Migration applies to prod automatically on the `main` promote (`migrate.yml`). It's additive and the table is empty — no risk.