### PR TITLE
fix(cheat-check): review fixes for the summary table

### DIFF
--- a/src/components/internals/Table/cheatTable.tsx
+++ b/src/components/internals/Table/cheatTable.tsx
@@ -51,7 +51,11 @@ export default function CheatTable({ final_data }: CheatTableProps) {
             <Fragment key={team.teamId}>
               <TableRow
                 key={team.teamId}
-                onClick={() => toggleTeam(team.teamId)}
+                onClick={(e) => {
+                  // Links inside cells shouldn't also toggle the row.
+                  if ((e.target as HTMLElement).closest("a, button")) return;
+                  toggleTeam(team.teamId);
+                }}
                 className="cursor-pointer"
               >
                 <TableCell
@@ -65,7 +69,7 @@ export default function CheatTable({ final_data }: CheatTableProps) {
                 {columns.map((col) => (
                   <TableCell
                     key={col.header}
-                    className={`${col.header == "Name" && "font-bold"} ${col.className}`}
+                    className={`${col.header == "Name" ? "font-bold" : ""} ${col.className}`}
                   >
                     {col.teamCell(team)}
                   </TableCell>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -8,7 +8,7 @@ const Table = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <table
     ref={ref}
-    className={cn("font-secondary", "caption-bottom text-sm", className)}
+    className={cn("caption-bottom text-sm", className)}
     {...props}
   />
 ));

--- a/src/lib/cheat-checks/finalTeamResult.ts
+++ b/src/lib/cheat-checks/finalTeamResult.ts
@@ -10,10 +10,14 @@ function CalculateResult(
   members: GroupedHackers[],
   checkType: HackerCheckType,
 ) {
-  const result = members.every((member) => {
-    const check = member.checks[checkType];
-    return check?.manualOverride ?? check?.passed ?? false;
-  });
+  // A team with no member rows has had no hacker checks run, which is not
+  // the same as all of them passing.
+  const result =
+    members.length > 0 &&
+    members.every((member) => {
+      const check = member.checks[checkType];
+      return check?.manualOverride ?? check?.passed ?? false;
+    });
 
   return {
     passed: result,
@@ -62,7 +66,7 @@ export function TeamResults(
       teamId: teamId,
       devPost: devPost,
       github: github,
-      name: teamEntry?.name ?? null,
+      name: teamEntry?.name ?? (teamId === "no-team" ? "No team" : null),
       members: members,
       checks: checks,
       finalResult: finalResult,

--- a/src/pages/internal/cheat-check.tsx
+++ b/src/pages/internal/cheat-check.tsx
@@ -5,7 +5,7 @@ import { Button } from "~/components/ui/button";
 import Link from "next/link";
 
 const CheatCheck = () => {
-  const { data: teams } = api.cheatCheck.getDisplayTeams.useQuery();
+  const { data: teams, error } = api.cheatCheck.getDisplayTeams.useQuery();
 
   return (
     <div className="bg-hw-linear-gradient-day flex min-h-screen flex-col items-center bg-primary-100 py-4">
@@ -16,7 +16,13 @@ const CheatCheck = () => {
         </Button>
       </div>
       <div className="z-10 w-full max-w-6xl px-4 font-secondary text-medium">
-        {teams ? <CheatTable final_data={teams} /> : <h2>Loading...</h2>}
+        {error ? (
+          <h2>Failed to load checks: {error.message}</h2>
+        ) : teams ? (
+          <CheatTable final_data={teams} />
+        ) : (
+          <h2>Loading...</h2>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Follow-ups from a post-merge review of #855.

- **Vacuous pass:** a team with zero hacker-check rows passed `IS_OF_AGE`/`IS_REGISTERED` via `every()` on an empty list, so its summary (and potentially `finalResult`) showed PASSED with no member checks run. Empty member list is now not-passed.
- Label the `no-team` bucket "No team" instead of rendering a blank name.
- Surface query errors on `/internal/cheat-check` — a failed `getDisplayTeams` previously showed "Loading..." forever.
- Clicking the LinkedIn/DevPost/GitHub links inside a row no longer also toggles row expansion.
- Non-Name cells no longer get a literal `false` class from the `&&` className.
- Revert the `font-secondary` addition to the shared `ui/table.tsx` — it changed every table consumer (data-table, food menu); the cheat-check page already sets `font-secondary` on its wrapper, which the table inherits.

`npx vitest run` green (261 passed), `tsc` clean, prettier clean.