### PR TITLE
[WRAPPED] Add devpost scraper for Wrapped tech stack

### DIFF
--- a/src/utils/devpost.test.ts
+++ b/src/utils/devpost.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DevpostScrapeError,
+  fetchDevpostTechStack,
+  normalizeDevpostUrl,
+  parseBuiltWith,
+} from "~/utils/devpost";
+
+function builtWithHtml(
+  tags: { label: string; recognized?: boolean }[],
+): string {
+  const items = tags
+    .map(({ label, recognized = true }) =>
+      recognized
+        ? `<li><span class="cp-tag recognized-tag"><a href="https://devpost.com/software/built-with/${label}">${label}</a></span></li>`
+        : `<li><span class="cp-tag">${label}</span></li>`,
+    )
+    .join("");
+
+  return `<html><body>
+    <div id="built-with" class="">
+      <h2>Built With</h2>
+      <ul class="no-bullet inline-list">${items}</ul>
+    </div>
+  </body></html>`;
+}
+
+describe("normalizeDevpostUrl", () => {
+  it("strips the _gl analytics blob off a copied project link", () => {
+    expect(
+      normalizeDevpostUrl(
+        "https://devpost.com/software/hackwestern?_gl=1*znq4gl*_gcl_au*NjM1ODE1MDUwLjE3ODgzNTU1MzA.*_ga*MTY4NTU4NDA3NQ..",
+      ),
+    ).toBe("https://devpost.com/software/hackwestern");
+  });
+
+  it("leaves an already-clean URL alone", () => {
+    expect(normalizeDevpostUrl("https://devpost.com/software/hackwestern")).toBe(
+      "https://devpost.com/software/hackwestern",
+    );
+  });
+
+  it("drops trailing sub-paths and fragments", () => {
+    expect(
+      normalizeDevpostUrl("https://devpost.com/software/hackwestern/edit#top"),
+    ).toBe("https://devpost.com/software/hackwestern");
+  });
+
+  it("accepts a bare host with no protocol", () => {
+    expect(normalizeDevpostUrl("devpost.com/software/hackwestern")).toBe(
+      "https://devpost.com/software/hackwestern",
+    );
+  });
+
+  it("accepts a hackathon subdomain and canonicalizes it", () => {
+    expect(
+      normalizeDevpostUrl("https://hackwestern.devpost.com/software/hackwestern"),
+    ).toBe("https://devpost.com/software/hackwestern");
+  });
+
+  it("rejects a non-DevPost host", () => {
+    expect(() =>
+      normalizeDevpostUrl("https://github.com/software/hackwestern"),
+    ).toThrow(DevpostScrapeError);
+  });
+
+  it("rejects a DevPost URL that is not a project page", () => {
+    expect(() => normalizeDevpostUrl("https://devpost.com/akuwuh")).toThrow(
+      DevpostScrapeError,
+    );
+    expect(() => normalizeDevpostUrl("https://devpost.com/software/")).toThrow(
+      DevpostScrapeError,
+    );
+  });
+
+  it("rejects empty and unparseable input", () => {
+    expect(() => normalizeDevpostUrl("   ")).toThrow(DevpostScrapeError);
+    expect(() => normalizeDevpostUrl("http://")).toThrow(DevpostScrapeError);
+  });
+});
+
+describe("parseBuiltWith", () => {
+  it("reads both linked and bare tags, in page order", () => {
+    const html = builtWithHtml([
+      { label: "css3" },
+      { label: "fastapi", recognized: false },
+      { label: "python" },
+      { label: "next.js", recognized: false },
+    ]);
+
+    expect(parseBuiltWith(html)).toEqual([
+      "css3",
+      "fastapi",
+      "python",
+      "next.js",
+    ]);
+  });
+
+  it("returns [] when the project lists no technologies", () => {
+    expect(parseBuiltWith(builtWithHtml([]))).toEqual([]);
+  });
+
+  it("returns [] when the page has no Built With section at all", () => {
+    expect(parseBuiltWith("<html><body><h1>hackwestern</h1></body></html>")).toEqual(
+      [],
+    );
+  });
+
+  it("ignores cp-tag spans outside the Built With section", () => {
+    const html = `<html><body>
+      <div id="submissions"><span class="cp-tag">not-a-tech</span></div>
+      ${builtWithHtml([{ label: "redis" }])}
+    </body></html>`;
+
+    expect(parseBuiltWith(html)).toEqual(["redis"]);
+  });
+
+  it("decodes entities and collapses whitespace in labels", () => {
+    const html = builtWithHtml([
+      { label: "c&#35;", recognized: false },
+      { label: "amazon\n  web   services", recognized: false },
+      { label: "at&amp;t", recognized: false },
+    ]);
+
+    expect(parseBuiltWith(html)).toEqual(["c#", "amazon web services", "at&t"]);
+  });
+
+  it("deduplicates case-insensitively, keeping the first spelling", () => {
+    const html = builtWithHtml([
+      { label: "React" },
+      { label: "react", recognized: false },
+    ]);
+
+    expect(parseBuiltWith(html)).toEqual(["React"]);
+  });
+});
+
+describe("fetchDevpostTechStack", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches the normalized URL and returns its tags", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(
+          builtWithHtml([{ label: "python" }, { label: "redis" }]),
+        ),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchDevpostTechStack("https://devpost.com/software/hackwestern?_gl=1*znq4gl"),
+    ).resolves.toEqual(["python", "redis"]);
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://devpost.com/software/hackwestern",
+    );
+  });
+
+  it("throws on a non-OK response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 404, text: () => "" }),
+    );
+
+    await expect(
+      fetchDevpostTechStack("https://devpost.com/software/gone"),
+    ).rejects.toThrow(DevpostScrapeError);
+  });
+
+  it("wraps a network failure rather than leaking it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    );
+
+    await expect(
+      fetchDevpostTechStack("https://devpost.com/software/hackwestern"),
+    ).rejects.toThrow(DevpostScrapeError);
+  });
+
+  it("rejects a bad URL without hitting the network", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchDevpostTechStack("https://example.com/software/hackwestern"),
+    ).rejects.toThrow(DevpostScrapeError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when DevPost bounces the project to a login page", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        url: "https://devpost.com/users/login",
+        text: () => Promise.resolve("<html><body>Log in</body></html>"),
+      }),
+    );
+
+    await expect(
+      fetchDevpostTechStack("https://devpost.com/software/d-iq67xn"),
+    ).rejects.toThrow(/private, unpublished, or deleted/);
+  });
+
+  it("throws when DevPost redirects anywhere else off the project", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        url: "https://devpost.com/",
+        text: () => Promise.resolve("<html></html>"),
+      }),
+    );
+
+    await expect(
+      fetchDevpostTechStack("https://devpost.com/software/hackwestern"),
+    ).rejects.toThrow(DevpostScrapeError);
+  });
+
+  it("still reads a project that redirected to a renamed slug", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        url: "https://devpost.com/software/hackwestern-renamed",
+        text: () => Promise.resolve(builtWithHtml([{ label: "python" }])),
+      }),
+    );
+
+    await expect(
+      fetchDevpostTechStack("https://devpost.com/software/hackwestern"),
+    ).resolves.toEqual(["python"]);
+  });
+
+  it("treats a genuinely empty Built With section as empty, not a failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        url: "https://devpost.com/software/bare",
+        text: () => Promise.resolve(builtWithHtml([])),
+      }),
+    );
+
+    await expect(
+      fetchDevpostTechStack("https://devpost.com/software/bare"),
+    ).resolves.toEqual([]);
+  });
+});

--- a/src/utils/devpost.test.ts
+++ b/src/utils/devpost.test.ts
@@ -35,9 +35,9 @@ describe("normalizeDevpostUrl", () => {
   });
 
   it("leaves an already-clean URL alone", () => {
-    expect(normalizeDevpostUrl("https://devpost.com/software/hackwestern")).toBe(
-      "https://devpost.com/software/hackwestern",
-    );
+    expect(
+      normalizeDevpostUrl("https://devpost.com/software/hackwestern"),
+    ).toBe("https://devpost.com/software/hackwestern");
   });
 
   it("drops trailing sub-paths and fragments", () => {
@@ -54,7 +54,9 @@ describe("normalizeDevpostUrl", () => {
 
   it("accepts a hackathon subdomain and canonicalizes it", () => {
     expect(
-      normalizeDevpostUrl("https://hackwestern.devpost.com/software/hackwestern"),
+      normalizeDevpostUrl(
+        "https://hackwestern.devpost.com/software/hackwestern",
+      ),
     ).toBe("https://devpost.com/software/hackwestern");
   });
 
@@ -101,9 +103,9 @@ describe("parseBuiltWith", () => {
   });
 
   it("returns [] when the page has no Built With section at all", () => {
-    expect(parseBuiltWith("<html><body><h1>hackwestern</h1></body></html>")).toEqual(
-      [],
-    );
+    expect(
+      parseBuiltWith("<html><body><h1>hackwestern</h1></body></html>"),
+    ).toEqual([]);
   });
 
   it("ignores cp-tag spans outside the Built With section", () => {
@@ -152,7 +154,9 @@ describe("fetchDevpostTechStack", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      fetchDevpostTechStack("https://devpost.com/software/hackwestern?_gl=1*znq4gl"),
+      fetchDevpostTechStack(
+        "https://devpost.com/software/hackwestern?_gl=1*znq4gl",
+      ),
     ).resolves.toEqual(["python", "redis"]);
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe(

--- a/src/utils/devpost.test.ts
+++ b/src/utils/devpost.test.ts
@@ -127,6 +127,30 @@ describe("parseBuiltWith", () => {
     expect(parseBuiltWith(html)).toEqual(["c#", "amazon web services", "at&t"]);
   });
 
+  it("leaves out-of-range numeric entities as literal text", () => {
+    const html = builtWithHtml([
+      { label: "bad&#999999999;tag", recognized: false },
+      { label: "hex&#x110000;tag", recognized: false },
+      { label: "python" },
+    ]);
+
+    expect(() => parseBuiltWith(html)).not.toThrow();
+    expect(parseBuiltWith(html)).toEqual([
+      "bad&#999999999;tag",
+      "hex&#x110000;tag",
+      "python",
+    ]);
+  });
+
+  it("still decodes entities at the edges of the valid range", () => {
+    const html = builtWithHtml([
+      { label: "&#65;", recognized: false },
+      { label: "&#x10FFFF;", recognized: false },
+    ]);
+
+    expect(parseBuiltWith(html)).toEqual(["A", String.fromCodePoint(0x10ffff)]);
+  });
+
   it("deduplicates case-insensitively, keeping the first spelling", () => {
     const html = builtWithHtml([
       { label: "React" },
@@ -196,6 +220,53 @@ describe("fetchDevpostTechStack", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("bounds the request with an abort signal it supplies itself", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: "https://devpost.com/software/hackwestern",
+      text: () => Promise.resolve(builtWithHtml([{ label: "python" }])),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchDevpostTechStack("https://devpost.com/software/hackwestern");
+
+    const signal = (
+      fetchMock.mock.calls[0]?.[1] as { signal?: AbortSignal } | undefined
+    )?.signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+  });
+
+  it("names a timeout for what it is", async () => {
+    const timeout = new Error("The operation was aborted");
+    timeout.name = "TimeoutError";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(timeout));
+
+    await expect(
+      fetchDevpostTechStack("https://devpost.com/software/slow"),
+    ).rejects.toThrow(/timed out after \d+ms/);
+  });
+
+  it("bounds the body read too, not just the response headers", async () => {
+    const timeout = new Error("terminated");
+    timeout.name = "TimeoutError";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        url: "https://devpost.com/software/slow",
+        // Headers arrive, then the stream stalls out.
+        text: () => Promise.reject(timeout),
+      }),
+    );
+
+    await expect(
+      fetchDevpostTechStack("https://devpost.com/software/slow"),
+    ).rejects.toThrow(/timed out after \d+ms/);
+  });
+
   it("throws when DevPost bounces the project to a login page", async () => {
     vi.stubGlobal(
       "fetch",
@@ -208,7 +279,7 @@ describe("fetchDevpostTechStack", () => {
     );
 
     await expect(
-      fetchDevpostTechStack("https://devpost.com/software/d-iq67xn"),
+      fetchDevpostTechStack("https://devpost.com/software/hackwestern"),
     ).rejects.toThrow(/private, unpublished, or deleted/);
   });
 

--- a/src/utils/devpost.ts
+++ b/src/utils/devpost.ts
@@ -1,0 +1,142 @@
+/**
+ * Scraping helpers for DevPost project pages.
+ *
+ * DevPost has no public API for a submission, so the "Built With" tags are read
+ * straight out of the page HTML. Kept free of any `~/server/db` import so it
+ * stays a pure fetch/parse module, like `~/utils/github`; the piece that writes
+ * to a team row lives in `~/server/api/utils/tech-stack`.
+ */
+
+const USER_AGENT =
+  "Mozilla/5.0 (compatible; HackWesternTechStack/1.0; +https://hackwestern.com)";
+
+/**
+ * Thrown when a DevPost URL is unusable or the page can't be read. Callers that
+ * scrape many teams in a row catch this per team rather than failing the batch.
+ */
+export class DevpostScrapeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DevpostScrapeError";
+  }
+}
+
+/**
+ * Strips a DevPost project URL down to `https://devpost.com/software/<slug>`.
+ */
+export function normalizeDevpostUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new DevpostScrapeError("No DevPost URL provided");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(
+      /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`,
+    );
+  } catch {
+    throw new DevpostScrapeError(`Not a valid URL: ${input}`);
+  }
+
+  const host = url.hostname.toLowerCase();
+  if (host !== "devpost.com" && !host.endsWith(".devpost.com")) {
+    throw new DevpostScrapeError(`Not a DevPost URL: ${input}`);
+  }
+
+  // ["", "software", "<slug>", ...rest]
+  const segments = url.pathname.split("/");
+  if (segments[1] !== "software" || !segments[2]) {
+    throw new DevpostScrapeError(`Not a DevPost project URL: ${input}`);
+  }
+
+  return `https://devpost.com/software/${segments[2]}`;
+}
+
+/** Decodes the handful of HTML entities that show up in tag text (`C#`, `AT&T`). */
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&#(\d+);/g, (_, code: string) =>
+      String.fromCodePoint(Number(code)),
+    )
+    .replace(/&#x([0-9a-f]+);/gi, (_, code: string) =>
+      String.fromCodePoint(parseInt(code, 16)),
+    )
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * Pulls the "Built With" tags out of a DevPost project page's HTML.
+ *
+ * Returns tags in page order (DevPost sorts them alphabetically), deduplicated
+ * case-insensitively. A project with no technologies listed yields `[]`.
+ */
+export function parseBuiltWith(html: string): string[] {
+  const section = /<div[^>]+id="built-with"[^>]*>([\s\S]*?)<\/div>/i.exec(html);
+  if (!section?.[1]) return [];
+
+  const tags: string[] = [];
+  const seen = new Set<string>();
+  const tagRegex =
+    /<span[^>]*class="[^"]*\bcp-tag\b[^"]*"[^>]*>([\s\S]*?)<\/span>/gi;
+
+  let match: RegExpExecArray | null;
+  while ((match = tagRegex.exec(section[1])) !== null) {
+    const label = decodeEntities(match[1]!.replace(/<[^>]*>/g, ""))
+      .replace(/\s+/g, " ")
+      .trim();
+    if (!label) continue;
+
+    const key = label.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    tags.push(label);
+  }
+
+  return tags;
+}
+
+/**
+ * Fetches a DevPost project page and returns its "Built With" technologies.
+ *
+ * Throws `DevpostScrapeError` if the URL isn't a DevPost project link or the
+ * page can't be fetched (a 404 means a deleted or still-private submission).
+ */
+export async function fetchDevpostTechStack(
+  devpostUrl: string,
+): Promise<string[]> {
+  const url = normalizeDevpostUrl(devpostUrl);
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT, Accept: "text/html" },
+    });
+  } catch (cause) {
+    throw new DevpostScrapeError(
+      `DevPost fetch failed for ${url}: ${String(cause)}`,
+    );
+  }
+
+  if (!res.ok) {
+    throw new DevpostScrapeError(
+      `DevPost fetch for ${url} failed with status ${res.status}`,
+    );
+  }
+
+  const landedOn = res.url ? new URL(res.url) : new URL(url);
+  if (!/^\/software\/[^/]+/.test(landedOn.pathname)) {
+    throw new DevpostScrapeError(
+      landedOn.pathname.startsWith("/users/login")
+        ? `DevPost sent ${url} to a login page — the project is private, unpublished, or deleted`
+        : `DevPost redirected ${url} to ${landedOn.href}, which is not a project page`,
+    );
+  }
+
+  return parseBuiltWith(await res.text());
+}

--- a/src/utils/devpost.ts
+++ b/src/utils/devpost.ts
@@ -10,6 +10,8 @@
 const USER_AGENT =
   "Mozilla/5.0 (compatible; HackWesternTechStack/1.0; +https://hackwestern.com)";
 
+const FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * Thrown when a DevPost URL is unusable or the page can't be read. Callers that
  * scrape many teams in a row catch this per team rather than failing the batch.
@@ -53,14 +55,20 @@ export function normalizeDevpostUrl(input: string): string {
   return `https://devpost.com/software/${segments[2]}`;
 }
 
+function decodeCodePoint(literal: string, raw: string, radix: number): string {
+  const code = parseInt(raw, radix);
+  if (!Number.isInteger(code) || code < 0 || code > 0x10ffff) return literal;
+  return String.fromCodePoint(code);
+}
+
 /** Decodes the handful of HTML entities that show up in tag text (`C#`, `AT&T`). */
 function decodeEntities(text: string): string {
   return text
-    .replace(/&#(\d+);/g, (_, code: string) =>
-      String.fromCodePoint(Number(code)),
+    .replace(/&#(\d+);/g, (match: string, code: string) =>
+      decodeCodePoint(match, code, 10),
     )
-    .replace(/&#x([0-9a-f]+);/gi, (_, code: string) =>
-      String.fromCodePoint(parseInt(code, 16)),
+    .replace(/&#x([0-9a-f]+);/gi, (match: string, code: string) =>
+      decodeCodePoint(match, code, 16),
     )
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
@@ -101,6 +109,17 @@ export function parseBuiltWith(html: string): string[] {
   return tags;
 }
 
+function asScrapeError(cause: unknown, url: string): DevpostScrapeError {
+  if (cause instanceof Error && cause.name === "TimeoutError") {
+    return new DevpostScrapeError(
+      `DevPost fetch for ${url} timed out after ${FETCH_TIMEOUT_MS}ms`,
+    );
+  }
+  return new DevpostScrapeError(
+    `DevPost fetch failed for ${url}: ${String(cause)}`,
+  );
+}
+
 /**
  * Fetches a DevPost project page and returns its "Built With" technologies.
  *
@@ -116,11 +135,10 @@ export async function fetchDevpostTechStack(
   try {
     res = await fetch(url, {
       headers: { "User-Agent": USER_AGENT, Accept: "text/html" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
   } catch (cause) {
-    throw new DevpostScrapeError(
-      `DevPost fetch failed for ${url}: ${String(cause)}`,
-    );
+    throw asScrapeError(cause, url);
   }
 
   if (!res.ok) {
@@ -138,5 +156,12 @@ export async function fetchDevpostTechStack(
     );
   }
 
-  return parseBuiltWith(await res.text());
+  let html: string;
+  try {
+    html = await res.text();
+  } catch (cause) {
+    throw asScrapeError(cause, url);
+  }
+
+  return parseBuiltWith(html);
 }

--- a/src/utils/devpost.ts
+++ b/src/utils/devpost.ts
@@ -4,7 +4,7 @@
  * DevPost has no public API for a submission, so the "Built With" tags are read
  * straight out of the page HTML. Kept free of any `~/server/db` import so it
  * stays a pure fetch/parse module, like `~/utils/github`; the piece that writes
- * to a team row lives in `~/server/api/utils/tech-stack`.
+ * to a team row lives in `~/server/api/utils/wrapped`.
  */
 
 const USER_AGENT =


### PR DESCRIPTION
#879, parent #863 

This PR adds a DevPost HTML scraper utility to support “Wrapped” tech stack collection by extracting the “Built With” tags from DevPost project pages (since DevPost doesn’t provide a public submission API).

## Changes:

Introduces src/utils/devpost.ts with URL normalization, HTML parsing, and a fetch wrapper that returns a project’s “Built With” technologies.
Adds src/utils/devpost.test.ts with Vitest coverage for URL normalization, parsing behavior, and fetch/redirect error handling.


